### PR TITLE
fix: plugins description should have correct whitespaces

### DIFF
--- a/scripts/build-plugin-list.js
+++ b/scripts/build-plugin-list.js
@@ -70,8 +70,7 @@ function extractPlugins(pluginContent) {
 
     const name = match[1]
     const url = match[2]
-    const description = match[3] ? match[3].trim().replace(/ {2,}/g, '') : ''
-
+    const description = match[3] ? match[3].trim().replace(/ {2,}/g, ' ') : ''
     return {
       name,
       url,


### PR DESCRIPTION
Fixes #81 

before:
![image](https://github.com/fastify/website/assets/5059100/485f02b8-d26c-428b-b59d-0522e559c21c)


after:
![image](https://github.com/fastify/website/assets/5059100/58e770d6-5812-460b-acbd-714a56689c5b)
