### PR TITLE
fix: only show good first issue labeled issues

### DIFF
--- a/src/pages/contribute.mdx
+++ b/src/pages/contribute.mdx
@@ -11,4 +11,4 @@ If you don't know where to start, you can have a look at the list of **good firs
 
 ## Good first issues
 
-<GoodFirstIssue url="https://goodfirstissue.fastify.io/api/find-issues?org=fastify" />
+<GoodFirstIssue url="https://goodfirstissue.fastify.io/api/find-issues?org=fastify&labels=good%20first%20issue" />


### PR DESCRIPTION
Currently alot of issues not marked as good first issue are shown. With this change, we filter for 'good first issue' labeled issues

## Description

<!-- Write a brief description of the changes introduced by this PR -->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->

## Check List

<!--
ATTENTION
Please follow this check list to ensure you've followed all items before opening this PR.
A PR will be merged only when the CI pipeline is successful and the approval process is completed.
-->

- [ ] I have read the [Contributing Guidelines](./CONTRIBUTING.md)
