### PR TITLE
chore: improve ci concurrency

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -113,7 +113,7 @@ jobs:
       - setup
       - build-and-upload
     concurrency:
-      group: ${{ github.ref }}-production
+      group: ${{ github.ref_name }}-production
       cancel-in-progress: true
     env:
       BASE_URL: ''
@@ -140,7 +140,7 @@ jobs:
       - setup
       - build-and-upload
     concurrency:
-      group: ${{ github.ref }}-staging
+      group: ${{ github.ref_name }}-staging
       cancel-in-progress: true
     env:
       BASE_URL: ''


### PR DESCRIPTION
related to the multiple failing pipeline due the @Uzlopak PRs gatling 😂 

The ref is always `main`:

> For workflows triggered by pull_request, this is the pull request merge branch.


https://docs.github.com/en/actions/learn-github-actions/contexts#github-context