### PR TITLE
Gitpodify

### DIFF
--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -1,0 +1,8 @@
+FROM gitpod/workspace-full
+
+# Install GitHub CLI
+RUN curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | sudo dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg \
+    && sudo chmod go+r /usr/share/keyrings/githubcli-archive-keyring.gpg \
+    && echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | sudo tee /etc/apt/sources.list.d/github-cli.list > /dev/null \
+    && sudo apt update \
+    && sudo apt install gh -y

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,0 +1,9 @@
+# Gitpod Configuration File
+# SEE https://www.gitpod.io/docs/references/gitpod-yml
+
+image:
+  file: .gitpod.Dockerfile
+
+tasks:
+  - init: npm install && npm --prefix ./scripts install
+    command: npm start

--- a/src/components/QuickStart/index.jsx
+++ b/src/components/QuickStart/index.jsx
@@ -168,7 +168,7 @@ start()`
       <h1>Quick start</h1>
 
       <a
-        href="https://gitpod.io/#https://github.com/gitpod-samples/template-fastify"
+        href="https://gitpod.io/#https://github.com/fastify/fastify-template-gitpod"
         target="_blank"
         rel="noreferrer nofollow">
         <img alt="Open in Gitpod" width="200" height="56" src="https://gitpod.io/button/open-in-gitpod.svg" />

--- a/src/components/QuickStart/index.jsx
+++ b/src/components/QuickStart/index.jsx
@@ -166,6 +166,14 @@ start()`
   return (
     <>
       <h1>Quick start</h1>
+
+      <a
+        href="https://gitpod.io/#https://github.com/gitpod-samples/template-fastify"
+        target="_blank"
+        rel="noreferrer nofollow">
+        <img alt="Open in Gitpod" width="200" height="56" src="https://gitpod.io/button/open-in-gitpod.svg" />
+      </a>
+
       <p>Get Fastify with NPM:</p>
 
       <CodeBlock language="bash">npm install fastify</CodeBlock>


### PR DESCRIPTION
## Description

Add Gitpod to the "Quick Start" section of the website, and gitpodify this repo.

I'm having an issue running where it's asking to run "npm run build:website" once, which seems to require being logged in with gh cli - is there a way around this?

<!-- Write a brief description of the changes introduced by this PR -->

## Related Issues

n/a

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->

## Check List

<!--
ATTENTION
Please follow this check list to ensure you've followed all items before opening this PR.
A PR will be merged only when the CI pipeline is successful and the approval process is completed.
-->

- [x] I have read the [Contributing Guidelines](./CONTRIBUTING.md)
