### PR TITLE
Don't remove extension in links

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -23,6 +23,8 @@ const config = {
   onBrokenLinks: 'warn',
   onBrokenMarkdownLinks: 'warn',
   favicon: 'img/favicon.ico',
+  // GitHub Pages redirects with a trailing slash, so this configures links to match
+  trailingSlash: true,
 
   // GitHub pages deployment config.
   organizationName: 'fastify',

--- a/scripts/process-releases.js
+++ b/scripts/process-releases.js
@@ -242,13 +242,6 @@ async function fixBrokenLinks(dir) {
     // double parenthesis in the docs
     // ((../Guides/Getting-Started.md#your-first-plugin))
     { regex: /\((\(\.\.\/Guides\/Getting-Started\.md.*\))\)?/g, replacement: '$1' },
-    // unneeded extensions in link or missing trailing dot
-    // [Validation and Serialization](./Validation-and-Serialization.md)
-    // [Logging](Logging.md)
-    {
-      regex: /\]\((?:.\/)?((?:\w|-)+)\.md(#(\w+))?\)/gi,
-      replacement: '](./$1$2)',
-    },
     // quotes in link
     // [Reply]('./Reply.md' "Reply")
     {


### PR DESCRIPTION
## Description

Don't remove the `.md` extension from markdown links since this prevents docusaurus from converting the link to an absolute URL, causing #157.

See also [docusaurus docs on Markdown links](https://docusaurus.io/docs/markdown-features/links).

I also added `trailingSlash: true` to the docusaurus config so that internal links have trailing slashes, which aligns with the Github Pages behavior of redirecting with a trailing slash.

## Related Issues

Fixes #157

## Check List

<!--
ATTENTION
Please follow this check list to ensure you've followed all items before opening this PR.
A PR will be merged only when the CI pipeline is successful and the approval process is completed.
-->

- [x] I have read the [Contributing Guidelines](./CONTRIBUTING.md)
