### PR TITLE
chore(license): make detectable by GitHub

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,9 +1,6 @@
 MIT License
 
-Copyright (c) 2016-2023 The Fastify Team
-
-The Fastify team members are listed at https://github.com/fastify/fastify#team
-and in the README file.
+Copyright (c) 2016-2023 The Fastify Team, listed at https://github.com/fastify/fastify#team and in the README file.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
## Description

Currently, GitHub cannot detect the license for this project. The note about the fastify team in the LICENSE file prevents GitHub from being able to detect the license. The GitHub documentation notes the following:

> If your repository is using a license that is listed on the Choose a License website and it's not displaying clearly at the top of the repository page, it may contain multiple licenses or other complexity. To have your license detected, simplify your _LICENSE_ file and note the complexity somewhere else, such as your repository's _README_ file.

In order to keep the whole thing intact and allow the license to be detected, I combined the three lines.

GitHub [uses the ruby gem licensee](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/licensing-a-repository#detecting-a-license) to detect the license. I used that to test the changes.

### Before:

```
$ licensee detect fastify-website
License:        NOASSERTION
Matched files:  LICENSE
LICENSE:
  Content hash:  78fdd4cae4b531973a9bfe40c9bf196003f42687
  License:       NOASSERTION
  Closest non-matching licenses:
    MIT similarity:    84.55%
    MIT-0 similarity:  66.14%
    NCSA similarity:   60.69%
```

### After:

```
$ licensee detect fastify-website
License:        MIT
Matched files:  LICENSE
LICENSE:
  Content hash:  4c2c763d64bbc7ef2e58b0ec6d06d90cee9755c9
  Attribution:   Copyright (c) 2016-2023 The Fastify Team, listed at https://github.com/fastify/fastify#team and in the README file.
  Confidence:    100.00%
  Matcher:       Licensee::Matchers::Exact
  License:       MIT
```

## Check List

- [x] I have read the [Contributing Guidelines](./CONTRIBUTING.md)
