### PR TITLE
Add security doc

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,4 @@
+# Security Policy
+
+Please see Fastify's [organization-wide security policy
+](https://github.com/fastify/.github/blob/main/SECURITY.md).


### PR DESCRIPTION
Not that it really matters since people are already ignoring GitHub telling them about (as shown in the screenshot), but I had difficulty deciding about reporting the recent offense because this doc wasn't in the repo.

<img width="1283" alt="website - Vivaldi 2024-05-18 08-10-11" src="https://github.com/fastify/website/assets/321201/583937d7-4e5c-4f67-9594-be9f030c51a6">
