### PR TITLE
fix height of sponsors

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -79,3 +79,7 @@
   color: rgb(28 30 33);
   padding: 2em 1em 1em;
 }
+
+.h-full {
+  height: 100%;
+}

--- a/src/pages/index.jsx
+++ b/src/pages/index.jsx
@@ -45,7 +45,7 @@ export default function Home() {
           <div className="container">
             <div className="row">
               <div className="col col--6">
-                <div className="alternate-sponsors">
+                <div className="alternate-sponsors h-full">
                   <h3>Sponsors</h3>
                   <p>
                     Would you like to sponsor Fastify financially? Support us on{' '}
@@ -57,7 +57,7 @@ export default function Home() {
               </div>
 
               <div className="col col--6">
-                <div className="alternate">
+                <div className="alternate h-full">
                   <h3>Using</h3>
                   <p>
                     Do you want your organisation to{' '}


### PR DESCRIPTION
fixes:

<img width="507" alt="Screenshot 2024-07-09 at 14 48 20" src="https://github.com/fastify/website/assets/74139498/2f657e5e-dc9d-4800-aa80-244d35c55457">

I'm not sure if a CSS library is used here, so I directly added `height: 100%`, but I can also use classes if that's better