### PR TITLE
fix: respect users preferred color scheme

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -91,6 +91,9 @@ const config = {
     ({
       // https://docusaurus.io/docs/api/themes/configuration
       image: 'img/logos/fastify-black.svg',
+      colorMode: {
+        respectPrefersColorScheme: true,
+      },
       docs: {
         sidebar: {
           autoCollapseCategories: true,


### PR DESCRIPTION
## Description

Made a small change to the Docusaurus config so that it now respects the user's preferred color theme, rather than always defaulting to the light theme and requiring users to manually switch to the dark theme by pressing a button.

Relevant Docusaurus documentation: [Color Mode Configuration](https://docusaurus.io/docs/api/themes/configuration#color-mode---dark-mode).

## Related Issues

None

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->

## Check List

<!--
ATTENTION
Please follow this check list to ensure you've followed all items before opening this PR.
A PR will be merged only when the CI pipeline is successful and the approval process is completed.
-->

- [x] I have read the [Contributing Guidelines](./CONTRIBUTING.md)
