### PR TITLE
ci: set workflow permissions to read-only by default

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -64,13 +64,15 @@ jobs:
         if: ${{ github.event_name != 'pull_request_target' }}
         uses: actions/checkout@v4
         with:
+          persist-credentials: false
           ref: main
 
       - name: Use Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 18
           cache: npm
+          check-latest: true
+          node-version: 18
           node-version-file: '.nvmrc'
 
       - name: Install Packages

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -18,9 +18,14 @@ on:
   # daily schedule
   workflow_call:
 
+permissions:
+  contents: read
+
 jobs:
   setup:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Select environment
         id: env-selector


### PR DESCRIPTION
This PR is created by a script. Please check the changes prior to merging.

This PR adds permissions to the workflow and job level, making the workflows read-only by default, and allowing write access only at the job level via granular permissions. This is regularly flagged by CodeQL, Step Security, [OSSF](https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions), and other security tools.
This change also allows the org to go read-only everywhere, see https://github.com/fastify/avvio/pull/308#issuecomment-2765300174