### PR TITLE
chore(data/team): add missing contributors

### DIFF
--- a/static/data/team.yml
+++ b/static/data/team.yml
@@ -96,18 +96,32 @@
       links:
         github: https://github.com/gurgunday
         npm: https://www.npmjs.com/~gurgunday
-    - name: Dan Castilo
-      sortname: Dan Castillo
+    - name: Dan Castillo
+      sortname: Castillo Dan
       githubId: '15673208'
       links:
         github: https://github.com/dancastillo
         npm: https://www.npmjs.com/~dancastillo
     - name: Jean Michelet
-      sortname: Jean Michelet
+      sortname: Michelet Jean
       githubId: '110341611'
       links:
         github: https://github.com/jean-michelet
         npm: https://www.npmjs.com/~jean-michelet
+    - name: Harry Brundage
+      sortname: Brundage Harry
+      githubId: '158950'
+      links:
+        github: https://github.com/airhorns
+        npm: https://www.npmjs.com/~airhorns
+        twitter: https://twitter.com/harrybrundage
+    - name: Luis Orbaiceta
+      sortname: Orbaiceta Luis
+      githubId: '44276180'
+      links:
+        github: https://github.com/luisorbaiceta
+        npm: https://www.npmjs.com/~luisorbaiceta
+        twitter: https://twitter.com/luisorbai
 
 - name: Past Collaborators
   people:


### PR DESCRIPTION
## Description

Add contributors who were present in https://github.com/fastify/fastify/blob/main/README.md#team but not on the website.

## Related Issues

N/A

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->

## Check List

<!--
ATTENTION
Please follow this check list to ensure you've followed all items before opening this PR.
A PR will be merged only when the CI pipeline is successful and the approval process is completed.
-->

- [x] I have read the [Contributing Guidelines](./CONTRIBUTING.md)
