### PR TITLE
ci: pin third-party actions to commit-hash

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -34,7 +34,7 @@ jobs:
           echo "website_url=${{ github.event_name == 'pull_request_target' && '/' || '/' }}" >> $GITHUB_OUTPUT
       - name: Get latest Fastify tag
         id: latest-fastify
-        uses: oprypin/find-latest-tag@v1
+        uses: oprypin/find-latest-tag@dd2729fe78b0bb55523ae2b2a310c6773a652bd1 # v1.1.2
         with:
           repository: fastify/fastify
           releases-only: true
@@ -86,7 +86,7 @@ jobs:
 
       - name: Get latest Fastify tag
         id: latest-fastify
-        uses: oprypin/find-latest-tag@v1
+        uses: oprypin/find-latest-tag@dd2729fe78b0bb55523ae2b2a310c6773a652bd1 # v1.1.2
         with:
           repository: fastify/fastify
           releases-only: true
@@ -180,7 +180,7 @@ jobs:
       - name: Display structure of downloaded files
         run: ls -R
       - name: Deploy to Netlify
-        uses: netlify/actions/cli@master
+        uses: netlify/actions/cli@3185065f4ab2f6df6f2ef41ee013626e1c02a426 # master
         id: deployment
         with:
           # https://cli.netlify.com/commands/deploy/

--- a/.github/workflows/optimize-images.yml
+++ b/.github/workflows/optimize-images.yml
@@ -50,7 +50,7 @@ jobs:
           npx svgo -rf ./static/img
 
       - name: Verify Changed files
-        uses: tj-actions/verify-changed-files@v20
+        uses: tj-actions/verify-changed-files@a1c6acee9df209257a246f2cc6ae8cb6581c1edf # v20.0.4
         id: verify-changed-files
         with:
           files: |
@@ -58,7 +58,7 @@ jobs:
 
       - name: Compress images
         id: calibre
-        uses: calibreapp/image-actions@main
+        uses: calibreapp/image-actions@737ceeaeed61e17b8d358358a303f1b8d177b779 # 1.1.0
         with:
           githubToken: ${{ secrets.GITHUB_TOKEN }}
           jpegQuality: '100'
@@ -73,7 +73,7 @@ jobs:
           github.event_name != 'pull_request' && (steps.calibre.outputs.markdown != '' || steps.verify-changed-files.outputs.files_changed == 'true')
 
 
-        uses: peter-evans/create-pull-request@v7
+        uses: peter-evans/create-pull-request@271a8d0340265f705b14b6d32b9829c1cb33d45e # v7.0.8
         with:
           title: 'chore: auto-compress images'
           branch-suffix: timestamp


### PR DESCRIPTION
Closes https://github.com/fastify/website/security/code-scanning/10 and 5 other code scanning alerts.

Most first-party actions now use https://github.com/actions/publish-immutable-action, which negates the need for commit hashes, but this is not available for third-party actions yet.