### PR TITLE
fix: Overlapping Home link on navbar #170

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -83,3 +83,12 @@
 .h-full {
   height: 100%;
 }
+.navbar__title.text--truncate {
+  display: none;
+}
+
+@media screen and (min-width: 768px) {
+  .navbar__title.text--truncate {
+    display: block;
+  }
+}

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -83,11 +83,12 @@
 .h-full {
   height: 100%;
 }
+
 .navbar__title.text--truncate {
   display: none;
 }
 
-@media screen and (min-width: 768px) {
+@media screen and (width >= 768px) {
   .navbar__title.text--truncate {
     display: block;
   }


### PR DESCRIPTION
## Description

This issue fixes displaying of home link on mobile/tab devices. Video of the same is attached. In mobile view clicking on main logo navigates to home page. Home page link is only visible on devices min width 768px.
## Related Issues

Overlapping Home link on navbar #170

Before fix current live

[before fix from 2025-07-28 14-40-09.webm](https://github.com/user-attachments/assets/5507ece8-6eeb-4d22-a6c6-c979797b891d)


After fix localhost

[Screencast from 2025-07-28 14-09-25.webm](https://github.com/user-attachments/assets/2724b5d3-cedf-4b38-ae99-ed69557c6367)
