### PR TITLE
feat(benchmarks): add more frameworks to comparison table

### DIFF
--- a/scripts/frameworks.json
+++ b/scripts/frameworks.json
@@ -40,5 +40,23 @@
     "tag": "hapi",
     "test": "https://github.com/fastify/benchmarks/blob/main/benchmarks/hapi.cjs",
     "repository": "https://github.com/hapijs/hapi"
+  },
+  {
+    "name": "Polka",
+    "tag": "polka",
+    "test": "https://github.com/fastify/benchmarks/blob/main/benchmarks/polka.cjs",
+    "repository": "https://github.com/lukeed/polka"
+  },
+  {
+    "name": "Micro",
+    "tag": "micro",
+    "test": "https://github.com/fastify/benchmarks/blob/main/benchmarks/micro.cjs",
+    "repository": "https://github.com/vercel/micro"
+  },
+  {
+    "name": "Tinyhttp",
+    "tag": "tinyhttp",
+    "test": "https://github.com/fastify/benchmarks/blob/main/benchmarks/tinyhttp.cjs",
+    "repository": "https://github.com/tinyhttp/tinyhttp"
   }
 ]


### PR DESCRIPTION
## Description

This PR adds more frameworks (Hono, H3, Polka, Micro, Tinyhttp) to the `frameworks.json` whitelist so they appear on the Fastify benchmarks page. These frameworks are already included in the upstream benchmark repo, and this change helps reflect current ecosystem trends.

This is my second contribution to Fastify and I’m excited to be exploring the project further. Thank you for the opportunity to contribute!



## Related Issues

Fixes #257


## Check List



- [x] I have read the [Contributing Guidelines](./CONTRIBUTING.md)
- [x] I have added necessary tests or changes (not needed here since it's JSON)
- [x] The PR description explains what I changed and why

