### PR TITLE
docs(ecosystem): added missing disclaimer under Community Plugins sec…

### DIFF
--- a/src/css/ecosystem.css
+++ b/src/css/ecosystem.css
@@ -24,3 +24,7 @@
 .grid-item-1 {
   background-color: var(--ifm-table-stripe-background);
 }
+
+.ecosystem-page h2 {
+  margin-top: 2rem;
+}

--- a/src/pages/ecosystem.mdx
+++ b/src/pages/ecosystem.mdx
@@ -15,10 +15,16 @@ export function PluginCount(props) {
 - We guarantee that every community plugin respects Fastify best practices (tests, etc) at the time they have been added to the list. We offer no guarantee on their maintenance
 - Can't find the plugin you're looking for? No problem, <Link to='/docs/latest/Guides/Write-Plugin'>you can learn how to do it!</Link>
 
+<div className="ecosystem-page">
+
 ## Core Plugins
 
 <PluginsTable plugins={plugins.corePlugins} />
 
 ## Community Plugins
+
+</div>
+
+> ℹ️ Note: Fastify community plugins are part of the broader community efforts, and we are thankful for these contributions. However, they are not maintained by the Fastify team. Use them at your own discretion. If you find malicious code, please [open an issue](https://github.com/fastify/fastify/issues/new/choose) or submit a PR to remove the plugin from the list.
 
 <PluginsTable plugins={plugins.communityPlugins} />


### PR DESCRIPTION
## Description

Added the missing disclaimer note under the **Community Plugins** section in `ecosystem.mdx`.  
This disclaimer clarifies that community plugins are not maintained by the Fastify team and should be used at the user's discretion.  

## Related Issues

Fixes #329

## Check List

- [x] I have read the [Contributing Guidelines](./CONTRIBUTING.md)
- [x] The change only affects documentation (no code changes involved)
- [x] Verified that the disclaimer renders correctly on the page