### PR TITLE
docs(examples): Fix ineffective TypeScript example

### DIFF
--- a/src/components/QuickStart/index.jsx
+++ b/src/components/QuickStart/index.jsx
@@ -128,7 +128,7 @@ fastify.listen({ port: 3000 }, (err) => {
   const typescript = `import Fastify, { FastifyInstance, RouteShorthandOptions } from 'fastify'
 import { Server, IncomingMessage, ServerResponse } from 'http'
 
-const server: FastifyInstance = Fastify({})
+const server: FastifyInstance<Server, IncomingMessage, ServerResponse> = Fastify()
 
 const opts: RouteShorthandOptions = {
   schema: {
@@ -155,6 +155,7 @@ const start = async () => {
 
     const address = server.server.address()
     const port = typeof address === 'string' ? address : address?.port
+    fastify.log.info(`server listening on port ${port}`)
 
   } catch (err) {
     server.log.error(err)

--- a/src/components/QuickStart/index.jsx
+++ b/src/components/QuickStart/index.jsx
@@ -128,7 +128,7 @@ fastify.listen({ port: 3000 }, (err) => {
   const typescript = `import Fastify, { FastifyInstance, RouteShorthandOptions } from 'fastify'
 import { Server, IncomingMessage, ServerResponse } from 'http'
 
-const server: FastifyInstance<Server, IncomingMessage, ServerResponse> = Fastify()
+const server: FastifyInstance<Server, IncomingMessage, ServerResponse> = Fastify({ logger: true })
 
 const opts: RouteShorthandOptions = {
   schema: {
@@ -155,7 +155,7 @@ const start = async () => {
 
     const address = server.server.address()
     const port = typeof address === 'string' ? address : address?.port
-    fastify.log.info(`server listening on port ${port}`)
+    server.log.info(`Server listening on port ${port}`)
 
   } catch (err) {
     server.log.error(err)


### PR DESCRIPTION
## Description

This fixes the currently very ineffective and (imo) broken TypeScript use example.

Issues addressed:
- example of actually using the imported TS types
- making use of the previously unused variable `port` to show how one would get the port

old version:
<img width="1101" height="992" alt="image" src="https://github.com/user-attachments/assets/356b8c3c-9bd7-493c-a14f-d6a200cd9a9c" />

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->

## Check List

<!--
ATTENTION
Please follow this check list to ensure you've followed all items before opening this PR.
A PR will be merged only when the CI pipeline is successful and the approval process is completed.
-->

- [x] I have read the [Contributing Guidelines](./CONTRIBUTING.md)
