### PR TITLE
chore: update docusaurus config

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -36,8 +36,8 @@ const config = {
 
   markdown: {
     hooks: {
-      onBrokenMarkdownLinks: 'warn'
-    }
+      onBrokenMarkdownLinks: 'warn',
+    },
   },
 
   // https://docusaurus.io/docs/using-plugins#using-presets
@@ -220,6 +220,8 @@ const config = {
             to: '/organizations',
           },
         ],
+        // @ts-ignore
+
         createRedirects(existingPath) {
           // Legacy/Retro compatibility:
 
@@ -230,6 +232,7 @@ const config = {
 
           // Redirect for old /docs/v3.<x>.<y>/ URLs to the latest v3 version
           if (existingPath.startsWith('/docs/v3')) {
+            // @ts-ignore
             return u.manageRedirects({
               existingPath,
               major: '3',
@@ -241,6 +244,7 @@ const config = {
 
           // Redirect for old /docs/v2.<x>.<y>/ URLs to the latest v2 version
           if (existingPath.startsWith('/docs/v2')) {
+            // @ts-ignore
             return u.manageRedirects({
               existingPath,
               major: '2',

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -21,7 +21,6 @@ const config = {
   url: 'https://fastify.io',
   baseUrl: BASE_URL,
   onBrokenLinks: 'warn',
-  onBrokenMarkdownLinks: 'warn',
   favicon: 'img/favicon.ico',
   // GitHub Pages redirects with a trailing slash, so this configures links to match
   trailingSlash: true,
@@ -33,6 +32,12 @@ const config = {
   i18n: {
     defaultLocale: 'en',
     locales: ['en'],
+  },
+
+  markdown: {
+    hooks: {
+      onBrokenMarkdownLinks: 'warn'
+    }
   },
 
   // https://docusaurus.io/docs/using-plugins#using-presets

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -220,8 +220,7 @@ const config = {
             to: '/organizations',
           },
         ],
-        // @ts-expect-error
-
+        // @ts-expect-error provided types doesn't match the real possible configuration
         createRedirects(existingPath) {
           // Legacy/Retro compatibility:
 
@@ -232,7 +231,7 @@ const config = {
 
           // Redirect for old /docs/v3.<x>.<y>/ URLs to the latest v3 version
           if (existingPath.startsWith('/docs/v3')) {
-            // @ts-expect-error
+            // @ts-expect-error provided types doesn't match the real possible configuration
             return u.manageRedirects({
               existingPath,
               major: '3',
@@ -244,7 +243,7 @@ const config = {
 
           // Redirect for old /docs/v2.<x>.<y>/ URLs to the latest v2 version
           if (existingPath.startsWith('/docs/v2')) {
-            // @ts-expect-error
+            // @ts-expect-error provided types doesn't match the real possible configuration
             return u.manageRedirects({
               existingPath,
               major: '2',

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -220,7 +220,7 @@ const config = {
             to: '/organizations',
           },
         ],
-        // @ts-ignore
+        // @ts-expect-error
 
         createRedirects(existingPath) {
           // Legacy/Retro compatibility:
@@ -232,7 +232,7 @@ const config = {
 
           // Redirect for old /docs/v3.<x>.<y>/ URLs to the latest v3 version
           if (existingPath.startsWith('/docs/v3')) {
-            // @ts-ignore
+            // @ts-expect-error
             return u.manageRedirects({
               existingPath,
               major: '3',
@@ -244,7 +244,7 @@ const config = {
 
           // Redirect for old /docs/v2.<x>.<y>/ URLs to the latest v2 version
           if (existingPath.startsWith('/docs/v2')) {
-            // @ts-ignore
+            // @ts-expect-error
             return u.manageRedirects({
               existingPath,
               major: '2',


### PR DESCRIPTION
Proposal:

- Update docusaurus config: `Docusaurus` has deprecated the `siteConfig.onBrokenMarkdownLinks` option ( see screenshot, see also here: https://docusaurus.io/docs/api/docusaurus-config#onBrokenMarkdownLinks ). This change moves the configuration to the suggested path: `siteConfig.markdown.hooks.onBrokenMarkdownLinks`, eliminating the warning during `build`/`serve`. 

<img width="1400" height="206" alt="Screenshot 2025-11-01 alle 17 26 18" src="https://github.com/user-attachments/assets/5fe42e89-e6be-4344-a871-2b6d45ecf0e9" />
