### PR TITLE
refactor: replace standard <a> tags with Docusaurus <Link>

### DIFF
--- a/src/theme/DocItem/Layout/index.js
+++ b/src/theme/DocItem/Layout/index.js
@@ -12,6 +12,8 @@ import DocItemContent from '@theme/DocItem/Content'
 import DocBreadcrumbs from '@theme/DocBreadcrumbs'
 import ContentVisibility from '@theme/ContentVisibility'
 import styles from './styles.module.css'
+import Link from '@docusaurus/Link'
+
 /**
  * Decide if the toc should be rendered, on mobile or desktop viewports
  */
@@ -53,7 +55,7 @@ export default function DocItemLayout({ children }) {
               <div className="alert alert--warning margin-top--md margin-bottom--md" role="alert">
                 <p>Version 3 and before of Fastify are no longer maintained.</p>
                 For information about support options for end-of-life versions, see the{' '}
-                <a href="/docs/latest/Reference/LTS">Long Term Support</a> page.
+                <Link to="/docs/latest/Reference/LTS">Long Term Support</Link> page.
               </div>
             )}
 

--- a/src/theme/DocVersionBanner/index.js
+++ b/src/theme/DocVersionBanner/index.js
@@ -103,7 +103,7 @@ function DocVersionBannerEnabled({ className, versionMetadata }) {
       {versionNumber < 4 && (
         <div className="margin-top--md">
           For information about support options for end-of-life versions, see the{' '}
-          <a href="/docs/latest/Reference/LTS">Long Term Support</a> page.
+          <Link to="/docs/latest/Reference/LTS">Long Term Support</Link> page.
         </div>
       )}
     </div>


### PR DESCRIPTION
Proposals:

- Replace standard `<a>` tags with Docusaurus `<Link>`: optimizes internal navigation and enables pre-fetching
- Fix CI/CD warnings: resolves `linting/build` warnings triggered by GitHub Actions in `DocVersionBanner` and `DocItem/Layout` components ( see screenshot )


<img width="1956" height="673" alt="warning" src="https://github.com/user-attachments/assets/2ebcc3b7-32f7-4cd6-8a08-df93c5ab85b4" />
