### PR TITLE
chore(deps): update undici, yaml, and directory-tree

### DIFF
--- a/scripts/package.json
+++ b/scripts/package.json
@@ -18,15 +18,15 @@
   ],
   "license": "MIT",
   "dependencies": {
-    "directory-tree": "^3.4.0",
+    "directory-tree": "^3.6.0",
     "glob": "^8.0.3",
     "pino": "^10.2.1",
     "pino-pretty": "^13.1.2",
     "prepend-file": "^2.0.1",
     "replace": "^1.2.2",
     "semver": "^7.7.3",
-    "undici": "^5.14.0",
-    "yaml": "^2.2.1"
+    "undici": "^7.19.2",
+    "yaml": "^2.8.2"
   },
   "devDependencies": {
     "@types/node": "^25.0.9"

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -18,7 +18,7 @@
   ],
   "license": "MIT",
   "dependencies": {
-    "directory-tree": "^3.6.0",
+    "directory-tree": "^3.0.0",
     "glob": "^8.0.3",
     "pino": "^10.2.1",
     "pino-pretty": "^13.1.2",


### PR DESCRIPTION
Proposal:

This PR upgrades dependencies in the `package.json` for `"internal scripts for the Fastify website"` to their latest versions ( a second step ), continuation of this PR: https://github.com/fastify/website/pull/389 

Updated dependency list:

undici: `^5.14.0` → `^7.19.2` 
yaml: `^2.2.1` → `^2.8.2`
directory-tree: `^3.4.0` → `^3.6.0`


This PR should resolved this update https://github.com/fastify/website/pull/380/changes ( dependabot )

