### PR TITLE
fix: align website footer legal text with OpenJS guidance

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -190,7 +190,7 @@ const config = {
             ],
           },
         ],
-        copyright: `Fastify, Copyright © 2016-${new Date().getFullYear()} <a href="https://openjsf.org">OpenJS Foundation</a> and The Fastify team, Licensed under <a href="https://github.com/fastify/fastify/blob/main/LICENSE">MIT</a>`,
+        copyright: `<p>Copyright <a href="https://openjsf.org">OpenJS Foundation</a> and Fastify contributors. All rights reserved. The <a href="https://openjsf.org">OpenJS Foundation</a> has registered trademarks and uses trademarks. For a list of trademarks of the <a href="https://openjsf.org">OpenJS Foundation</a>, please see our <a href="https://trademark-policy.openjsf.org">Trademark Policy</a> and <a href="https://trademark-list.openjsf.org">Trademark List</a>. Trademarks and logos not indicated on the <a href="https://trademark-list.openjsf.org">list of OpenJS Foundation trademarks</a> are trademarks&trade; or registered&reg; trademarks of their respective holders. Use of them does not imply any affiliation with or endorsement by them.</p><p><a href="https://openjsf.org">The OpenJS Foundation</a> | <a href="https://terms-of-use.openjsf.org">Terms of Use</a> | <a href="https://privacy-policy.openjsf.org">Privacy Policy</a> | <a href="https://bylaws.openjsf.org">Bylaws</a> | <a href="https://code-of-conduct.openjsf.org">Code of Conduct</a> | <a href="https://trademark-policy.openjsf.org">Trademark Policy</a> | <a href="https://trademark-list.openjsf.org">Trademark List</a> | <a href="https://www.linuxfoundation.org/cookies">Cookie Policy</a></p>`,
       },
       prism: {
         theme: lightCodeTheme,


### PR DESCRIPTION
## Description
- replace the footer legal text in `docusaurus.config.js` with the OpenJS Foundation approved footer language
- include the full trademark/legal notice paragraph
- include the full OpenJS legal links row (Terms of Use, Privacy Policy, Bylaws, Code of Conduct, Trademark Policy, Trademark List, Cookie Policy)
- use `Fastify contributors` as the project name in the approved template

Fixes #400

## Verification
- `npm run lint:js`
- `npm run lint:style`
- compared resulting footer text/links against OpenJS guidance:
  https://github.com/openjs-foundation/artwork#copyright-notices-for-project-website-footers