### PR TITLE
Make plugins table search case-insensitive

### DIFF
--- a/src/components/Ecosystem/PluginsTable.jsx
+++ b/src/components/Ecosystem/PluginsTable.jsx
@@ -7,8 +7,9 @@ const PluginsTable = (props) => {
   const [descriptionFilter, setDescriptionFilter] = useState()
 
   const filtered = props.plugins.filter((plugin) => {
-    const nameCondition = nameFilter == undefined || plugin.name.includes(nameFilter)
-    const descriptionCondition = descriptionFilter == undefined || plugin.description.includes(descriptionFilter)
+    const nameCondition = nameFilter == undefined || plugin.name.toLowerCase().includes(nameFilter.toLowerCase())
+    const descriptionCondition =
+      descriptionFilter == undefined || plugin.description.toLowerCase().includes(descriptionFilter.toLowerCase())
 
     return nameCondition && descriptionCondition
   })


### PR DESCRIPTION
## Description

The plugins table on the ecosystem page has a search function that is currently case-sensitive. This can be a confusing experience for users. This PR updates the search algorithm to perform a case-insensitive comparison.

## Related Issues
None

## Check List

- [x ] I have read the [Contributing Guidelines](./CONTRIBUTING.md)
