### PR TITLE
Add docusaurus-plugin-copy-page-button

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -297,6 +297,7 @@ const config = {
         },
       },
     ],
+    'docusaurus-plugin-copy-page-button',
   ],
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "@mdx-js/react": "^3.1.1",
         "@orama/plugin-docusaurus-v3": "^3.1.18",
         "clsx": "^2.1.1",
+        "docusaurus-plugin-copy-page-button": "^0.6.2",
         "prism-react-renderer": "^2.4.1",
         "react": "^19.2.4",
         "react-dom": "^19.2.4",
@@ -8297,9 +8298,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8312,9 +8310,6 @@
       "integrity": "sha512-LD2fytxZJZ6xzOKnMbIpgzFOuIKlxVOpiMAXawsAZ2mHBPEYOnLRK5TTEsID6z4eM23DuO88X0Tq1mErHMVq0A==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -8329,9 +8324,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8344,9 +8336,6 @@
       "integrity": "sha512-cYRpV4650z2I3/s6+5/LONkjIz8MBeqrk+vPXV10ORBnshpn8S32bPqQ2Utv39jCiDcO2eJTuSlPXpnvmaIgRA==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -8695,9 +8684,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8711,9 +8697,6 @@
       "integrity": "sha512-GFWfAhVhWGd4r6UxmnKRTBwP1qmModHtd5gkraeW2G490BpFOZkFtem8yuX2NyafIP/mGpRJgTJ2PwohQkUY/Q==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -8729,9 +8712,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8745,9 +8725,6 @@
       "integrity": "sha512-PQUobbhLTQT5yz/SPg116VJBgz+XOtXt8D1ck+sfJJhuEsMj2jSej5yTdp8CvWBSceu+WW+ibVL6dm0ptG5fcA==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -12931,6 +12908,19 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/docusaurus-plugin-copy-page-button": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/docusaurus-plugin-copy-page-button/-/docusaurus-plugin-copy-page-button-0.6.2.tgz",
+      "integrity": "sha512-RbldmCJ6FEYx515ptp1Ei9WwQAQyK6ty5UaHVaSlOyBfh/Nm+wu+6y3g/V7sVejBrMCxpGLnAuIJn3h8nqdjcQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0"
+      },
+      "peerDependencies": {
+        "@docusaurus/core": "^3.0.0",
+        "react": "^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/dom-converter": {

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "@mdx-js/react": "^3.1.1",
     "@orama/plugin-docusaurus-v3": "^3.1.18",
     "clsx": "^2.1.1",
+    "docusaurus-plugin-copy-page-button": "^0.6.2",
     "prism-react-renderer": "^2.4.1",
     "react": "^19.2.4",
     "react-dom": "^19.2.4",


### PR DESCRIPTION
## Summary

Adds [`docusaurus-plugin-copy-page-button`](https://www.npmjs.com/package/docusaurus-plugin-copy-page-button) to the Fastify website so readers can copy any documentation page as clean markdown — useful when piping plugin docs, hooks, or route options into ChatGPT, Claude, Perplexity, or Gemini.

The plugin auto-injects a small "Copy page" button + dropdown into the doc page's table-of-contents area. The dropdown offers:

- Copy as markdown
- View as markdown
- Open in ChatGPT / Claude / Perplexity / Gemini

Live preview of the UI: https://portdeveloper.github.io/copy-page-button-showcase/

## Relationship to existing `llms.txt`

The website already runs `@signalwire/docusaurus-plugin-llms-txt` to generate `/llms.txt` and `/llms-full.txt` at build time — great for whole-corpus consumption. This PR doesn't replace or duplicate that. The plugin adds the UI affordance: a reader on a specific page can grab just that page's markdown, or one-click open it in an AI tool, without going through the corpus index.

## Adoption

The plugin currently ships on docs sites for React Native (just merged via facebook/react-native-website#5085), Puppeteer, Arbitrum, Cardano, Sui, Ethereum execution-apis, and several others — full list in the [project README](https://github.com/portdeveloper/docusaurus-plugin-copy-page-button#used-by).

## Changes

- Added `'docusaurus-plugin-copy-page-button'` to the `plugins` array in `docusaurus.config.js`
- Added `docusaurus-plugin-copy-page-button@^0.6.2` to `dependencies`
- Resulting `package-lock.json` updates

## Notes

- `package-lock.json` shows incidental `"libc"` field removals on a handful of optional native deps. That's npm 10.9.8 (what I ran with) normalizing keys differently from the lockfile's original generator; happy to regenerate with a specific npm version if maintainers want a cleaner diff.
- I did not run the full `scripts/build-website.sh` locally — it downloads Fastify release artifacts to generate `versions.json`. The plugin add is a single string in the `plugins` array, identical to the pattern landed in 4 sibling PRs (Jellyfin, Seeed Studio Wiki, PlayCanvas Developer, Temporal) where the full build was verified.