### PR TITLE
fix(scripts): tolerate N/A entries in benchmark download

### DIFF
--- a/scripts/download-benchmarks.js
+++ b/scripts/download-benchmarks.js
@@ -97,34 +97,32 @@ const getBlob = async (blobUrl) => {
 }
 
 function buildBenchmarksJSON(data, date = 'Unknown') {
-  const maxSpeed = data
+  const numericRequests = data
+    .filter((item) => frameworkTags.includes(item.name))
     .filter(({ requests }) => !isNaN(requests))
     .map(({ requests }) => parseInt(requests))
-    .reduce((max, req) => (req > max ? req : max), 0)
 
-  const json = {
+  const maxSpeed = numericRequests.length ? numericRequests.reduce((max, req) => (req > max ? req : max), 0) : 0
+
+  return {
     date,
     reference: maxSpeed,
     frameworks: arrayDefaultFrameworks
       .map((framework) => {
-        const item = data.find(({ name }) => name == framework.tag)
+        const item = data.find(({ name }) => name === framework.tag)
         return {
           ...framework,
-          requests: item.requests,
+          requests: isNaN(item.requests) ? 0 : parseInt(item.requests),
         }
       })
-      .sort((a, b) => {
-        return b.requests - a.requests
-      }),
+      .sort((a, b) => b.requests - a.requests),
   }
-
-  return json
 }
 
 function isValidBenchmark(data) {
   return data
     .filter((item) => frameworkTags.includes(item.name)) //
-    .every((item) => !isNaN(item.requests))
+    .some((item) => !isNaN(item.requests))
 }
 
 async function getDataAsJSON(url) {
@@ -140,6 +138,7 @@ async function getDataAsJSON(url) {
 
   const { body } = await request(url, {
     headers,
+    signal: AbortSignal.timeout(10000),
   })
   return body.json()
 }

--- a/scripts/download-benchmarks.js
+++ b/scripts/download-benchmarks.js
@@ -115,6 +115,7 @@ function buildBenchmarksJSON(data, date = 'Unknown') {
           requests: isNaN(item.requests) ? 0 : parseInt(item.requests),
         }
       })
+      .filter(f => f.requests > 0)
       .sort((a, b) => b.requests - a.requests),
   }
 }

--- a/scripts/download-benchmarks.js
+++ b/scripts/download-benchmarks.js
@@ -115,7 +115,7 @@ function buildBenchmarksJSON(data, date = 'Unknown') {
           requests: isNaN(item.requests) ? 0 : parseInt(item.requests),
         }
       })
-      .filter(f => f.requests > 0)
+      .filter((f) => f.requests > 0)
       .sort((a, b) => b.requests - a.requests),
   }
 }


### PR DESCRIPTION
## What

The benchmark dataset in fastify/benchmarks now contains entries with `requests: "N/A"` (e.g. restify) when a framework cannot be benchmarked. This broke the build in two ways:

1. `isValidBenchmark` rejected the whole file because **one** tracked framework had a non-numeric value (`every` → `some` fix).
2. When the 10-commit fallback also failed, the step timed out at 30 minutes because there was no per-request timeout.

## Changes

- `isValidBenchmark`: `every` → `some` — passes when at least one tracked framework has a numeric value.
- `buildBenchmarksJSON`: coerces non-numeric `requests` to `0` so the sort comparator stays deterministic; guards `maxSpeed` against an empty numeric set.
- `getDataAsJSON`: adds `AbortSignal.timeout(10000)` to each HTTP request so a slow GitHub API call fails in 10s instead of hanging the workflow.

## Root cause trace

```
download-benchmarks.js → throws "Unable to find a valid benchmark result"
  → static/generated/benchmarks.json is never written
    → docusaurus.config.js:15 → u.checkGeneratedData() throws "Missing generated file: static/generated/benchmarks.json"
      → Docusaurus catches and re-throws as "Docusaurus could not load module at path …/docusaurus.config.js"
        → Build step times out at 30 minutes (workflow run 26875115530)
```

## Test

Ran the script locally against the live data — `restify` now appears in `benchmarks.json` with `requests: 0` and all other frameworks are unaffected.

Closes the build failures on `deploy-website.yml` (last 10 runs all failing).
Unlocks to #437 