### PR TITLE
refactor(QuickStart): replace Docusaurus CodeBlock styles

### DIFF
--- a/src/components/QuickStart/index.jsx
+++ b/src/components/QuickStart/index.jsx
@@ -1,9 +1,10 @@
 import React from 'react'
 import Tabs from '@theme/Tabs'
 import TabItem from '@theme/TabItem'
-import CodeBlock from '@theme/CodeBlock'
 import Link from '@docusaurus/Link'
 import Heading from '@theme/Heading'
+import CodeBlock from '@theme/CodeBlock'
+import styles from './styles.module.css'
 
 export default function QuickStart() {
   const esm = `// Import the framework and instantiate it
@@ -169,24 +170,36 @@ start()`
       <Heading as={'h1'}>Quick start</Heading>
       <p>Get Fastify with NPM:</p>
 
-      <CodeBlock language="bash">npm install fastify</CodeBlock>
+      <div className={styles.qsCodeblock}>
+        <CodeBlock language="bash">npm install fastify</CodeBlock>
+      </div>
       <p>
         Then create <code>server.js</code> and add the following content:
       </p>
-      <Tabs>
-        <TabItem value="esm" label="ESM">
-          <CodeBlock language="js">{esm}</CodeBlock>
-        </TabItem>
-        <TabItem value="cjs" label="CJS">
-          <CodeBlock language="js">{cjs}</CodeBlock>
-        </TabItem>
-      </Tabs>
+      <div className={styles.qsCodeblock}>
+        <Tabs>
+          <TabItem value="esm" label="ESM">
+            <CodeBlock language="js" noTitle>
+              {esm}
+            </CodeBlock>
+          </TabItem>
+          <TabItem value="cjs" label="CJS">
+            <CodeBlock language="js" noTitle>
+              {cjs}
+            </CodeBlock>
+          </TabItem>
+        </Tabs>
+      </div>
 
       <p>Finally, launch the server with:</p>
-      <CodeBlock language="bash">node server</CodeBlock>
+      <div className={styles.qsCodeblock}>
+        <CodeBlock language="bash">node server</CodeBlock>
+      </div>
 
       <p>and test it with:</p>
-      <CodeBlock language="bash">curl http://localhost:3000</CodeBlock>
+      <div className={styles.qsCodeblock}>
+        <CodeBlock language="bash">curl http://localhost:3000</CodeBlock>
+      </div>
 
       <Heading as={'h2'}>Using CLI</Heading>
       <p>
@@ -197,29 +210,35 @@ start()`
         to create a new scaffolding project:
       </p>
 
-      <CodeBlock language="bash">
-        npm install --global fastify-cli
-        <br />
-        fastify generate myproject
-      </CodeBlock>
+      <div className={styles.qsCodeblock}>
+        <CodeBlock language="bash">{`npm install --global fastify-cli\n\nfastify generate myproject`}</CodeBlock>
+      </div>
 
       <p>Or to create a TypeScript project:</p>
 
-      <CodeBlock language="bash">fastify generate myproject --lang=ts</CodeBlock>
+      <div className={styles.qsCodeblock}>
+        <CodeBlock language="bash">fastify generate myproject --lang=ts</CodeBlock>
+      </div>
 
       <Heading as={'h2'}>Request/Response validation and hooks</Heading>
       <p>
         Fastify can do much more than this. For example, you can easily provide input and output validation using JSON
         Schema and perform specific operations before the handler is executed:
       </p>
-      <Tabs>
-        <TabItem value="esm" label="ESM">
-          <CodeBlock language="js">{exampleRequestResponseEsm}</CodeBlock>
-        </TabItem>
-        <TabItem value="cjs" label="CJS">
-          <CodeBlock language="js">{exampleRequestResponseCjs}</CodeBlock>
-        </TabItem>
-      </Tabs>
+      <div className={styles.qsCodeblock}>
+        <Tabs>
+          <TabItem value="esm" label="ESM">
+            <CodeBlock language="js" noTitle>
+              {exampleRequestResponseEsm}
+            </CodeBlock>
+          </TabItem>
+          <TabItem value="cjs" label="CJS">
+            <CodeBlock language="js" noTitle>
+              {exampleRequestResponseCjs}
+            </CodeBlock>
+          </TabItem>
+        </Tabs>
+      </div>
 
       <Heading as={'h2'}>TypeScript Support</Heading>
       <p>
@@ -239,11 +258,15 @@ start()`
         This ensures within the server handler we also get <code>http.ServerResponse</code> with correct typings on{' '}
         <code>reply.res</code>.
       </p>
-      <Tabs>
-        <TabItem value="esm" label="TypeScript">
-          <CodeBlock language="js">{typescript}</CodeBlock>
-        </TabItem>
-      </Tabs>
+      <div className={styles.qsCodeblock}>
+        <Tabs>
+          <TabItem value="esm" label="TypeScript">
+            <CodeBlock language="js" noTitle>
+              {typescript}
+            </CodeBlock>
+          </TabItem>
+        </Tabs>
+      </div>
       <p>
         Visit the <Link to="/docs/latest">Documentation</Link> to learn more about all the features that Fastify has to
         offer.

--- a/src/components/QuickStart/styles.module.css
+++ b/src/components/QuickStart/styles.module.css
@@ -1,9 +1,12 @@
 .qsCodeblock {
-  border: 0.5px solid #2d3040;
+  border: 0.5px solid var(--ifm-color-emphasis-300);
   border-radius: 12px;
   overflow: hidden;
   margin: 8px 0;
-  background: #16181d;
+  background: var(--ifm-background-surface-color);
+  transition:
+    background-color 0.3s ease,
+    border-color 0.3s ease;
 }
 
 .qsCodeblock > div,
@@ -17,32 +20,37 @@
 }
 
 .qsCodeblock [class*='tabList__'] {
-  background: #1c1f28 !important;
-  border-bottom: 0.5px solid #2d3040 !important;
+  background: var(--ifm-color-emphasis-100) !important;
+  border-bottom: 0.5px solid var(--ifm-color-emphasis-300) !important;
   border-radius: 0 !important;
   margin: 0 !important;
   padding: 0 !important;
   gap: 0 !important;
+  transition:
+    background-color 0.3s ease,
+    border-color 0.3s ease;
 }
 
 .qsCodeblock [class*='tabList__'] [aria-selected='true'] {
   font-size: 13px !important;
   font-weight: 500 !important;
-  color: #25c2a0 !important;
+  color: var(--ifm-color-primary) !important;
   background: none !important;
   margin: 10px 0 0 !important;
   border: none !important;
   text-transform: uppercase;
+  transition: color 0.3s ease;
 }
 
 .qsCodeblock [class*='tabList__'] [aria-selected='false'] {
   font-size: 13px !important;
   font-weight: 500 !important;
   border-bottom: 2px solid transparent !important;
-  color: #6c7086 !important;
+  color: var(--ifm-color-emphasis-600) !important;
   background: none !important;
   margin: 10px 0 0 !important;
   text-transform: uppercase;
+  transition: color 0.3s ease;
 }
 
 .qsCodeblock [role='tabpanel'] {
@@ -55,36 +63,43 @@
   border: none !important;
   box-shadow: none !important;
   margin: 0;
-  background: #16181d !important;
+  background: var(--ifm-background-surface-color) !important;
+  transition: background-color 0.3s ease;
 }
 
 .qsCodeblock [class*='codeBlockContent'] {
-  background: #16181d !important;
+  background: var(--ifm-background-surface-color) !important;
+  transition: background-color 0.3s ease;
 }
 
 .qsCodeblock [class*='codeBlockContent'] pre {
-  background: #16181d;
+  background: var(--ifm-background-surface-color) !important;
   margin: 0;
+  transition: background-color 0.3s ease;
 }
 
 .qsCodeblock [class*='codeBlockTitle'] {
-  background: #1c1f28 !important;
-  border-bottom: 0.5px solid #2d3040 !important;
+  background: var(--ifm-color-emphasis-100) !important;
+  border-bottom: 0.5px solid var(--ifm-color-emphasis-300) !important;
   border-radius: 0 !important;
-  color: #25c2a0 !important;
+  color: var(--ifm-color-primary) !important;
   font-size: 11px !important;
   font-weight: 500 !important;
   letter-spacing: 0.07em !important;
   text-transform: uppercase !important;
   padding: 8px 16px !important;
   margin: 0 !important;
+  transition:
+    background-color 0.3s ease,
+    border-color 0.3s ease,
+    color 0.3s ease;
 }
 
 .qsCodeblock [class*='copyButton'] {
-  color: #25c2a0 !important;
+  color: var(--ifm-color-primary) !important;
 }
 
 .qsCodeblock [class*='copyButton']:hover {
-  color: #25c2a0bb !important;
+  opacity: 0.75;
   background: transparent !important;
 }

--- a/src/components/QuickStart/styles.module.css
+++ b/src/components/QuickStart/styles.module.css
@@ -1,12 +1,3 @@
-.subLabel {
-  font-family: var(--ifm-font-family-monospace);
-  font-size: 11px;
-  color: var(--ifm-color-primary);
-  letter-spacing: 0.08em;
-  margin-bottom: 0.5rem !important;
-  margin-top: 1.5rem !important;
-}
-
 .qsCodeblock {
   border: 0.5px solid #2d3040;
   border-radius: 12px;

--- a/src/components/QuickStart/styles.module.css
+++ b/src/components/QuickStart/styles.module.css
@@ -1,0 +1,99 @@
+.subLabel {
+  font-family: var(--ifm-font-family-monospace);
+  font-size: 11px;
+  color: var(--ifm-color-primary);
+  letter-spacing: 0.08em;
+  margin-bottom: 0.5rem !important;
+  margin-top: 1.5rem !important;
+}
+
+.qsCodeblock {
+  border: 0.5px solid #2d3040;
+  border-radius: 12px;
+  overflow: hidden;
+  margin: 8px 0;
+  background: #16181d;
+}
+
+.qsCodeblock > div,
+.qsCodeblock [class*='tabItem'],
+.qsCodeblock [role='tabpanel'],
+.qsCodeblock [class*='codeBlockContainer'],
+.qsCodeblock [class*='codeBlockContent'] pre {
+  margin: 0 !important;
+  padding-top: 0 !important;
+  padding-bottom: 0 !important;
+}
+
+.qsCodeblock [class*='tabList__'] {
+  background: #1c1f28 !important;
+  border-bottom: 0.5px solid #2d3040 !important;
+  border-radius: 0 !important;
+  margin: 0 !important;
+  padding: 0 !important;
+  gap: 0 !important;
+}
+
+.qsCodeblock [class*='tabList__'] [aria-selected='true'] {
+  font-size: 13px !important;
+  font-weight: 500 !important;
+  color: #25c2a0 !important;
+  background: none !important;
+  margin: 10px 0px 0px 0px !important;
+  border: none !important;
+  text-transform: uppercase;
+}
+
+.qsCodeblock [class*='tabList__'] [aria-selected='false'] {
+  font-size: 13px !important;
+  font-weight: 500 !important;
+  border-bottom: 2px solid transparent !important;
+  color: #6c7086 !important;
+  background: none !important;
+  margin: 10px 0px 0px 0px !important;
+  text-transform: uppercase;
+}
+
+.qsCodeblock [role='tabpanel'] {
+  padding: 0 !important;
+  margin: 0 !important;
+}
+
+.qsCodeblock [class*='codeBlockContainer'] {
+  border-radius: 0 !important;
+  border: none !important;
+  box-shadow: none !important;
+  margin: 0 !important;
+  background: #16181d !important;
+}
+
+.qsCodeblock [class*='codeBlockContent'] {
+  background: #16181d !important;
+}
+
+.qsCodeblock [class*='codeBlockContent'] pre {
+  background: #16181d !important;
+  margin: 0 !important;
+}
+
+.qsCodeblock [class*='codeBlockTitle'] {
+  background: #1c1f28 !important;
+  border-bottom: 0.5px solid #2d3040 !important;
+  border-radius: 0 !important;
+  color: #25c2a0 !important;
+  font-size: 11px !important;
+  font-weight: 500 !important;
+  letter-spacing: 0.07em !important;
+  text-transform: uppercase !important;
+  padding: 8px 16px !important;
+  margin: 0 !important;
+}
+
+.qsCodeblock [class*='copyButton'] {
+  color: #25c2a0 !important;
+}
+
+.qsCodeblock [class*='copyButton']:hover {
+  color: #25c2a0bb !important;
+  background: transparent !important;
+}

--- a/src/components/QuickStart/styles.module.css
+++ b/src/components/QuickStart/styles.module.css
@@ -11,9 +11,9 @@
 .qsCodeblock [role='tabpanel'],
 .qsCodeblock [class*='codeBlockContainer'],
 .qsCodeblock [class*='codeBlockContent'] pre {
-  margin: 0 !important;
-  padding-top: 0 !important;
-  padding-bottom: 0 !important;
+  margin: 0;
+  padding-top: 0;
+  padding-bottom: 0;
 }
 
 .qsCodeblock [class*='tabList__'] {
@@ -46,15 +46,15 @@
 }
 
 .qsCodeblock [role='tabpanel'] {
-  padding: 0 !important;
-  margin: 0 !important;
+  padding: 0;
+  margin: 0;
 }
 
 .qsCodeblock [class*='codeBlockContainer'] {
   border-radius: 0 !important;
   border: none !important;
   box-shadow: none !important;
-  margin: 0 !important;
+  margin: 0;
   background: #16181d !important;
 }
 
@@ -64,7 +64,7 @@
 
 .qsCodeblock [class*='codeBlockContent'] pre {
   background: #16181d !important;
-  margin: 0 !important;
+  margin: 0;
 }
 
 .qsCodeblock [class*='codeBlockTitle'] {

--- a/src/components/QuickStart/styles.module.css
+++ b/src/components/QuickStart/styles.module.css
@@ -63,7 +63,7 @@
 }
 
 .qsCodeblock [class*='codeBlockContent'] pre {
-  background: #16181d !important;
+  background: #16181d;
   margin: 0;
 }
 

--- a/src/components/QuickStart/styles.module.css
+++ b/src/components/QuickStart/styles.module.css
@@ -30,7 +30,7 @@
   font-weight: 500 !important;
   color: #25c2a0 !important;
   background: none !important;
-  margin: 10px 0px 0px 0px !important;
+  margin: 10px 0 0 !important;
   border: none !important;
   text-transform: uppercase;
 }
@@ -41,7 +41,7 @@
   border-bottom: 2px solid transparent !important;
   color: #6c7086 !important;
   background: none !important;
-  margin: 10px 0px 0px 0px !important;
+  margin: 10px 0 0 !important;
   text-transform: uppercase;
 }
 

--- a/src/theme/CodeBlock/index.js
+++ b/src/theme/CodeBlock/index.js
@@ -1,0 +1,8 @@
+import React from 'react'
+import OriginalCodeBlock from '@docusaurus/theme-classic/lib/theme/CodeBlock/index.js'
+
+export default function CodeBlock({ language, title, noTitle, ...props }) {
+  const resolvedTitle = noTitle ? undefined : (title ?? language)
+
+  return <OriginalCodeBlock language={language} title={resolvedTitle} {...props} />
+}


### PR DESCRIPTION
Proposal:

- Replaces Docusaurus CodeBlock styles
- Added `CodeBlock` function in theme directory
- Added `styles.module.css` in `QuickStart` directory
- Update `index.jsx` in `QuickStart` directory

--- 

- Preview Quickstart:
<img width="1421" height="1063" alt="quickstart-refactor" src="https://github.com/user-attachments/assets/1ab6f049-7d9c-4016-b032-468d0bd45092" />

- Preview Using CLI:
<img width="1391" height="393" alt="quickstart-refactor-1" src="https://github.com/user-attachments/assets/35363438-2b4d-4ab8-8571-fd6ab2d79ce9" />

- Preview Tab ESM: 
<img width="1379" height="1143" alt="quickstart-refactor-2" src="https://github.com/user-attachments/assets/c9d921a4-6dc5-4124-bae2-3b7efbe16dd2" />

- Preview Tab CJS:
<img width="1333" height="434" alt="quickstart-refactor-4" src="https://github.com/user-attachments/assets/029cff40-dce5-407a-954d-daf1339079c6" />


- Preview Typescript Support:
<img width="1369" height="1162" alt="quickstart-refactor-3" src="https://github.com/user-attachments/assets/83aa6268-9590-47a1-8c5f-e9c48202b14e" />

---


cc @fastify/frontend @fastify/website 