### PR TITLE
docs: fix broken links

### DIFF
--- a/CONTRIBUTING.MD
+++ b/CONTRIBUTING.MD
@@ -25,7 +25,7 @@ This repository follows the same rules as a Fastify plugin repository. A detaile
 
 ## Becoming a collaborator
 
-We follow the [Fastify organization Governance model](https://github.com/fastify/fastify/blob/main/GOVERNANCE.md#collaborator-nominations) so it is necessary to contribute to this repository in order to become a member.
+We follow the [Fastify organization Governance model](https://github.com/fastify/.github/blob/main/GOVERNANCE.md#collaborator-nominations) so it is necessary to contribute to this repository in order to become a member.
 
 ## Debugging failing checks
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ npm install
 
 ### Setup
 
-Before we start the development server we will need to fetch some of the docs from [Fastify Repo](https://github.com/fastify/fastify.git). This requires Github CLI to be installed which can be found [here](https://cli.github.com/).
+Before we start the development server we will need to fetch some of the docs from [Fastify Repo](https://github.com/fastify/fastify). This requires Github CLI to be installed which can be found [here](https://cli.github.com/).
 
 After installing [GitHub CLI](https://cli.github.com/) ensure you are logged in by running;
 


### PR DESCRIPTION
Fixes 404s, 3xx redirections, and missing fragments in the documentation. Part of general link cleanup being tracked in https://github.com/fastify/accept-negotiator/pull/71