### PR TITLE
Stop publishing stale v1 and v2 docs

### DIFF
--- a/scripts/build-website.sh
+++ b/scripts/build-website.sh
@@ -11,8 +11,7 @@ npm --prefix ./scripts install
 ####### Download Phase
 
 if [[ $SKIP_DOWNLOADS != "true" ]]; then
-  ./scripts/download-releases.sh --major 1
-  ./scripts/download-releases.sh --major 2
+  # v1 and v2 docs contain stale source links and are no longer published.
   ./scripts/download-releases.sh --major 3
   ./scripts/download-releases.sh --major 4
   ./scripts/download-releases.sh --minor 5

--- a/scripts/process-releases.js
+++ b/scripts/process-releases.js
@@ -14,6 +14,7 @@ const prependFile = require('prepend-file')
 
 const sidebarsTemplate = require('../sidebars-template.json')
 const processDocusaurusV3Upgrade = require('./process-docusaurus-v3-upgrade')
+const MIN_DOCS_MAJOR = 3
 const log = require('pino')({
   level: process.env.LOG_LEVEL || 'debug',
   transport: {
@@ -41,6 +42,11 @@ async function processReleases(opts) {
   log.info('Cleaned up versioned_sidebars folder')
 
   for (const docTree of getDocFolders(releasesFolder)) {
+    if (docTree.semver.major < MIN_DOCS_MAJOR) {
+      log.info(`Skipping ${docTree.releseTag} because v1 and v2 docs are no longer published`)
+      continue
+    }
+
     log.info(`Processing ${docTree.releseTag}`)
 
     const requiresRootFolder = docTree.semver.major <= 2


### PR DESCRIPTION
## Description

Summary
- Stops downloading Fastify v1 and v2 docs during website builds.
- Skips v1 and v2 release folders during release processing, including when cached release data is restored in CI.
- Keeps currently published v3, v4, and v5 docs generation unchanged.

Validation
- `npm ci` passed.
- `npm run lint:js` passed.
- `npm run lint:style` passed.
- `node --check scripts/process-releases.js` passed.
- `git diff --cached --check` passed.
- PowerShell content check confirmed the v1/v2 download commands are absent.
- `npm run format:check` did not pass locally because the current Windows checkout reports existing Prettier warnings across 56 files; no broad formatting changes were included.
- `scripts/build-website.sh` was not run locally because this Windows host only exposes the WSL bash launcher and `/bin/bash` is unavailable. CI runs the website build on Ubuntu.

Notes
- Fixes #440.
- No runtime code changes; this only changes documentation generation.

## Related Issues

Fixes #440

## Check List

- [x] I have read the [Contributing Guidelines](./CONTRIBUTING.md)