### PR TITLE
fix: remove duplicate input ids in PluginsTable

### DIFF
--- a/src/components/Ecosystem/PluginsTable.jsx
+++ b/src/components/Ecosystem/PluginsTable.jsx
@@ -24,14 +24,14 @@ const PluginsTable = (props) => {
 
   return (
     <div className="grid-container">
-      <div className="grid-item-header">
-        <label htmlFor="name">Name</label>
-        <input id="name" type="text" onKeyUp={(event) => setNameFilter(event.target.value)} />
-      </div>
-      <div className="grid-item-header">
-        <label htmlFor="description">Description</label>
-        <input id="description" type="text" onKeyUp={(event) => setDescriptionFilter(event.target.value)} size="40" />
-      </div>
+      <label className="grid-item-header">
+        Name
+        <input type="text" onKeyUp={(event) => setNameFilter(event.target.value)} />
+      </label>
+      <label className="grid-item-header">
+        Description
+        <input type="text" onKeyUp={(event) => setDescriptionFilter(event.target.value)} size="40" />
+      </label>
       {filtered.map((plugin, index) => [
         <div key={`plugin-name-${index}`} className={`grid-item grid-item-${index % 2}`}>
           <Link to={plugin.url}>{plugin.name}</Link>

--- a/src/css/ecosystem.css
+++ b/src/css/ecosystem.css
@@ -12,9 +12,6 @@
   display: flex;
   flex-direction: column;
   padding-bottom: 5px;
-}
-
-.grid-item-header label {
   font-weight: 700;
 }
 


### PR DESCRIPTION
## Description

Remove id="name" and id="description" from PluginsTable's filter inputs and wrap each <input> inside its <label>. PluginsTable component renders twice on the Ecosystem page, so the ids collide and break label-input association.

## Related Issues
https://github.com/fastify/website/pull/446#issue-4762153913 - missed the multi-instance case there.

## Check List

- [x] I have read the [Contributing Guidelines](./CONTRIBUTING.md)
