### PR TITLE
fix: allow forks checkout

### DIFF
--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -5,10 +5,10 @@ on:
     branches:
       - main
       - next
-      - 'v*'
+      - "v*"
     paths-ignore:
-      - '.github/**'
-      - '.vscode/**'
+      - ".github/**"
+      - ".vscode/**"
   # workflow_dispatch means to manual deploy production
   workflow_dispatch:
   # workflow_call means to deploy production from external workflow
@@ -25,19 +25,20 @@ jobs:
     permissions:
       contents: read
     env:
-      BASE_URL: '/'
+      BASE_URL: "/"
     steps:
       - name: Checkout
         uses: actions/checkout@v7
         with:
           persist-credentials: false
+          allow-unsafe-pr-checkout: true
 
       - name: Use Node.js
         uses: actions/setup-node@v6
         with:
           cache: npm
           check-latest: true
-          node-version-file: '.nvmrc'
+          node-version-file: ".nvmrc"
 
       - name: Install Packages
         run: npm ci --ignore-scripts
@@ -72,7 +73,7 @@ jobs:
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v5
         with:
-          path: './build'
+          path: "./build"
 
   deploy-to-production:
     needs:
@@ -81,7 +82,7 @@ jobs:
       group: ${{ github.ref_name }}-production
       cancel-in-progress: true
     env:
-      BASE_URL: ''
+      BASE_URL: ""
     permissions:
       pages: write
       id-token: write

--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -5,10 +5,10 @@ on:
     branches:
       - main
       - next
-      - "v*"
+      - 'v*'
     paths-ignore:
-      - ".github/**"
-      - ".vscode/**"
+      - '.github/**'
+      - '.vscode/**'
   # workflow_dispatch means to manual deploy production
   workflow_dispatch:
   # workflow_call means to deploy production from external workflow
@@ -25,20 +25,19 @@ jobs:
     permissions:
       contents: read
     env:
-      BASE_URL: "/"
+      BASE_URL: '/'
     steps:
       - name: Checkout
         uses: actions/checkout@v7
         with:
           persist-credentials: false
-          allow-unsafe-pr-checkout: true
 
       - name: Use Node.js
         uses: actions/setup-node@v6
         with:
           cache: npm
           check-latest: true
-          node-version-file: ".nvmrc"
+          node-version-file: '.nvmrc'
 
       - name: Install Packages
         run: npm ci --ignore-scripts
@@ -73,7 +72,7 @@ jobs:
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v5
         with:
-          path: "./build"
+          path: './build'
 
   deploy-to-production:
     needs:
@@ -82,7 +81,7 @@ jobs:
       group: ${{ github.ref_name }}-production
       cancel-in-progress: true
     env:
-      BASE_URL: ""
+      BASE_URL: ''
     permissions:
       pages: write
       id-token: write

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -24,6 +24,7 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.ref }}
           repository: ${{ github.event.pull_request.head.repo.full_name }}
+          allow-unsafe-pr-checkout: true
 
       - name: Use Node.js
         uses: actions/setup-node@v6


### PR DESCRIPTION
Unblocks: https://github.com/fastify/website/pull/443

> Error: Refusing to check out fork pull request code from a 'pull_request_target' workflow. This workflow runs with the base repository's GITHUB_TOKEN, secrets, default-branch cache scope, and runner access. Fetching and executing a fork's code in that trusted context commonly leads to "pwn request" vulnerabilities. To opt in, review the risks at https://gh.io/securely-using-pull_request_target and set 'allow-unsafe-pr-checkout: true' on the actions/checkout step.