### PR TITLE
fix(styles): darken core features cards background in dark mode

### DIFF
--- a/src/components/CoreFeatures/styles.module.css
+++ b/src/components/CoreFeatures/styles.module.css
@@ -36,6 +36,10 @@
   box-shadow: 0 8px 24px rgb(0 0 0 / 10%);
 }
 
+[data-theme='dark'] .card {
+  background: var(--ifm-background-color);
+}
+
 .accent {
   position: absolute;
   top: 0;


### PR DESCRIPTION
Proposal:

- Darkens the background of the "Core features" cards on the homepage, but only in dark mode. ( a small correction )

Changes:
- Added a `[data-theme='dark'] .card` override in `CoreFeatures/styles.module.css` setting the background to `#1b1b1d` (Infima's standard dark background color).
- Light mode is untouched.

before:
<img width="1484" height="602" alt="screenshot-before" src="https://github.com/user-attachments/assets/1fdae797-6261-4a57-b939-f06c1d70c404" />


after:

<img width="1483" height="610" alt="screenshot-after" src="https://github.com/user-attachments/assets/b1ccc339-e0b4-475e-8a57-1df9ef699d42" />


light mode:

<img width="1405" height="588" alt="screenshot-light-mode" src="https://github.com/user-attachments/assets/bc8eb096-27ac-4399-825e-75c45ca83633" />

--- 

cc @fastify/website 