### PR TITLE
feat(website): modernize plugins, organizations and contribute UI

### DIFF
--- a/src/components/Ecosystem/PluginsTable.jsx
+++ b/src/components/Ecosystem/PluginsTable.jsx
@@ -1,53 +1,123 @@
-import React, { useState } from 'react'
+import React, { useId, useMemo, useState } from 'react'
 import ReactMarkdown from 'react-markdown'
 import Link from '@docusaurus/Link'
 
-const PluginsTable = (props) => {
-  const [nameFilter, setNameFilter] = useState()
-  const [descriptionFilter, setDescriptionFilter] = useState()
+const SearchIcon = () => (
+  <svg className="plugins-field__icon" width="16" height="16" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+    <circle cx="11" cy="11" r="7" stroke="currentColor" strokeWidth="2" />
+    <path d="m20 20-3.5-3.5" stroke="currentColor" strokeWidth="2" strokeLinecap="round" />
+  </svg>
+)
 
-  const filtered = props.plugins.filter((plugin) => {
-    const nameCondition = nameFilter == undefined || plugin.name.toLowerCase().includes(nameFilter.toLowerCase())
-    const descriptionCondition =
-      descriptionFilter == undefined || plugin.description.toLowerCase().includes(descriptionFilter.toLowerCase())
+const ClearIcon = () => (
+  <svg width="14" height="14" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+    <path d="M6 6l12 12M18 6 6 18" stroke="currentColor" strokeWidth="2.4" strokeLinecap="round" />
+  </svg>
+)
 
-    return nameCondition && descriptionCondition
-  })
+const PluginField = ({ id, label, value, onChange, placeholder }) => (
+  <label className="plugins-field" htmlFor={id}>
+    <span className="plugins-field__label">{label}</span>
+    <span className="plugins-field__control">
+      <SearchIcon />
+      <input
+        id={id}
+        type="text"
+        value={value}
+        placeholder={placeholder}
+        autoComplete="off"
+        onChange={(event) => onChange(event.target.value)}
+      />
+      {value ? (
+        <button
+          type="button"
+          className="plugins-field__clear"
+          aria-label={`Clear ${label.toLowerCase()} filter`}
+          onClick={() => onChange('')}>
+          <ClearIcon />
+        </button>
+      ) : null}
+    </span>
+  </label>
+)
 
-  const emptyRow = []
-  if (filtered.length == 0) {
-    emptyRow.push({
-      name: 'No match',
-      description: 'No match',
-    })
-  }
+const PluginsTable = ({ plugins, variant = 'community' }) => {
+  const idPrefix = useId()
+  const [nameFilter, setNameFilter] = useState('')
+  const [descriptionFilter, setDescriptionFilter] = useState('')
+
+  const filtered = useMemo(
+    () =>
+      plugins.filter((plugin) => {
+        const nameCondition = !nameFilter || plugin.name.toLowerCase().includes(nameFilter.toLowerCase())
+        const descriptionCondition =
+          !descriptionFilter || plugin.description.toLowerCase().includes(descriptionFilter.toLowerCase())
+
+        return nameCondition && descriptionCondition
+      }),
+    [plugins, nameFilter, descriptionFilter],
+  )
+
+  const hasFilters = Boolean(nameFilter || descriptionFilter)
+  const badgeLabel = variant === 'official' ? 'Official' : 'Community'
 
   return (
-    <div className="grid-container">
-      <label className="grid-item-header">
-        Name
-        <input type="text" onKeyUp={(event) => setNameFilter(event.target.value)} />
-      </label>
-      <label className="grid-item-header">
-        Description
-        <input type="text" onKeyUp={(event) => setDescriptionFilter(event.target.value)} size="40" />
-      </label>
-      {filtered.map((plugin, index) => [
-        <div key={`plugin-name-${index}`} className={`grid-item grid-item-${index % 2}`}>
-          <Link to={plugin.url}>{plugin.name}</Link>
-        </div>,
-        <div key={`plugin-description-${index}`} className={`grid-item grid-item-${index % 2}`}>
-          <ReactMarkdown skipHtml={true}>{plugin.description}</ReactMarkdown>
-        </div>,
-      ])}
-      {emptyRow.map((row) => [
-        <div key="no-result-name" className="grid-item grid-item-0">
-          {row.name}
-        </div>,
-        <div key="no-result-description" className="grid-item grid-item-0">
-          {row.description}
-        </div>,
-      ])}
+    <div className="plugins-table">
+      <div className="plugins-toolbar">
+        <PluginField
+          id={`${idPrefix}-name`}
+          label="Name"
+          value={nameFilter}
+          onChange={setNameFilter}
+          placeholder="Search by plugin name…"
+        />
+        <PluginField
+          id={`${idPrefix}-description`}
+          label="Description"
+          value={descriptionFilter}
+          onChange={setDescriptionFilter}
+          placeholder="Search by keyword…"
+        />
+        <div className="plugins-toolbar__meta">
+          <span className="plugins-count">
+            <strong>{filtered.length}</strong> of {plugins.length} plugins
+          </span>
+          {hasFilters ? (
+            <button
+              type="button"
+              className="plugins-reset"
+              onClick={() => {
+                setNameFilter('')
+                setDescriptionFilter('')
+              }}>
+              Reset filters
+            </button>
+          ) : null}
+        </div>
+      </div>
+
+      {filtered.length > 0 ? (
+        <ul className="plugins-list">
+          {filtered.map((plugin) => (
+            <li key={plugin.name} className="plugins-card">
+              <div className="plugins-card__header">
+                <Link to={plugin.url} className="plugins-card__name">
+                  {plugin.name}
+                </Link>
+                <span className={`plugins-badge plugins-badge--${variant}`}>{badgeLabel}</span>
+              </div>
+              <div className="plugins-card__description">
+                <ReactMarkdown skipHtml={true}>{plugin.description}</ReactMarkdown>
+              </div>
+            </li>
+          ))}
+        </ul>
+      ) : (
+        <div className="plugins-empty">
+          <p className="plugins-empty__title">No plugins match your search</p>
+          <p className="plugins-empty__subtitle">Try a different name or keyword, or reset the filters above.</p>
+        </div>
+      )}
     </div>
   )
 }

--- a/src/components/GoodFirstIssue/index.jsx
+++ b/src/components/GoodFirstIssue/index.jsx
@@ -59,14 +59,14 @@ function GoodFirstIssue({ url }) {
 
   if (loading)
     return (
-      <div className="alert alert--secondary" role="alert">
-        Loading...
+      <div className={css.statusPanel} role="status">
+        Loading good first issues…
       </div>
     )
 
   if (error)
     return (
-      <div className="alert alert--danger" role="alert">
+      <div className={`${css.statusPanel} ${css.statusPanelError}`} role="alert">
         Error: {error.message}
       </div>
     )
@@ -80,39 +80,37 @@ function GoodFirstIssue({ url }) {
       return projects[issue.project.name].selected
     })
 
-    setProjects(projects)
+    setProjects({ ...projects })
     setFilteredIssues(filteredIssues)
   }
 
   return (
-    <div className="container">
-      <div className="row">
-        <div className="col col--4 margin--none">
-          <nav className="col-demo item shadow--lw">
-            <p className={css.panelHeading}>Projects</p>
-            <div className={`avatar margin-bottom--sm ${css.projectItem}`}>
-              <input
-                type="checkbox"
-                checked={checkAllProjects}
-                onChange={() => setCheckAllProjects(!checkAllProjects)}
-              />
-              <div className="avatar__intro">
-                <div className="avatar__name">All the projects</div>
-                <small className="avatar__subtitle">{issues.length} issues</small>
-              </div>
-            </div>
-            <hr />
+    <div className={css.layout}>
+      <nav className={css.sidebar}>
+        <p className={css.sidebarHeading}>Projects</p>
 
-            {Object.values(projects)
-              .sort(byCount)
-              .map((project) => ProjectFilter({ ...project, toggle: toggleProject.bind(this, project.name) }))}
-          </nav>
+        <label className={css.projectItem}>
+          <input type="checkbox" checked={checkAllProjects} onChange={() => setCheckAllProjects(!checkAllProjects)} />
+          <span className={css.projectItemName}>All the projects</span>
+          <span className={css.projectItemCount}>{issues.length}</span>
+        </label>
+
+        <hr className={css.sidebarDivider} />
+
+        <div className={css.projectList}>
+          {Object.values(projects)
+            .sort(byCount)
+            .map((project) => (
+              <ProjectFilter key={project.name} {...project} toggle={toggleProject.bind(this, project.name)} />
+            ))}
         </div>
-        <div className="col col--8">
-          <div className="col-demo">
-            <Issues issues={filteredIssues} />
-          </div>
-        </div>
+      </nav>
+
+      <div className={css.issuesColumn}>
+        <p className={css.issuesCount}>
+          <strong>{filteredIssues.length}</strong> of {issues.length} open issues
+        </p>
+        <Issues issues={filteredIssues} />
       </div>
     </div>
   )
@@ -124,42 +122,53 @@ function ProjectFilter({ name, count, selected, toggle }) {
   }
 
   return (
-    <div className={`avatar margin-bottom--sm ${css.projectItem}`} key={name} onClick={onChange}>
+    <label className={css.projectItem}>
       <input type="checkbox" checked={Boolean(selected)} onChange={onChange} />
-      <div className="avatar__intro">
-        <div className="avatar__name">{name}</div>
-        <small className="avatar__subtitle">{count} issues</small>
-      </div>
-    </div>
+      <span className={css.projectItemName}>{name}</span>
+      <span className={css.projectItemCount}>{count}</span>
+    </label>
   )
+}
+
+function labelVariant(label) {
+  const value = label.toLowerCase()
+  if (value.includes('bug')) {
+    return 'bug'
+  }
+
+  if (value.includes('good first issue')) {
+    return 'goodFirstIssue'
+  }
+
+  if (value.includes('help wanted')) {
+    return 'helpWanted'
+  }
+
+  if (value.includes('question')) {
+    return 'question'
+  }
+
+  return 'default'
 }
 
 function Issue(props) {
   return (
-    <div className="card-demo margin-bottom--sm" key={props.url}>
-      <div className="card">
-        <div className="card__header">
-          <div className="avatar">
-            <div className="avatar__intro">
-              <div className="avatar__name">
-                <Link to={props.url}>{props.title}</Link>
-              </div>
-              <small className="avatar__subtitle">
-                Project <Link to={props.project.url}>{props.project.name}</Link>
-              </small>
-            </div>
-          </div>
+    <div className={css.issueCard} key={props.url}>
+      <Link to={props.url} className={css.issueTitle}>
+        {props.title}
+      </Link>
+      <p className={css.issueProject}>
+        Project <Link to={props.project.url}>{props.project.name}</Link>
+      </p>
+      {props.labels.length > 0 ? (
+        <div className={css.issueLabels}>
+          {props.labels.map((label) => (
+            <span key={label} className={`${css.label} ${css[`label--${labelVariant(label)}`]}`}>
+              {label}
+            </span>
+          ))}
         </div>
-        <div className="card__footer">
-          {props.labels.map((label) => {
-            return (
-              <span key={label} className="badge badge--secondary margin-right--xs">
-                {label}
-              </span>
-            )
-          })}
-        </div>
-      </div>
+      ) : null}
     </div>
   )
 }
@@ -167,12 +176,13 @@ function Issue(props) {
 function Issues({ issues }) {
   if (issues.length === 0) {
     return (
-      <div>
-        <strong>No issue available 😱</strong>
+      <div className={css.emptyState}>
+        <p className={css.emptyStateTitle}>No issues match this filter 😱</p>
+        <p className={css.emptyStateSubtitle}>Try selecting a different project on the left.</p>
       </div>
     )
   }
-  return issues.map((issue) => Issue(issue))
+  return <div className={css.issuesList}>{issues.map((issue) => Issue(issue))}</div>
 }
 
 function byCount(a, b) {

--- a/src/components/GoodFirstIssue/styles.module.css
+++ b/src/components/GoodFirstIssue/styles.module.css
@@ -1,24 +1,204 @@
-:root {
-  --fty-head-bg: #ededed;
+.layout {
+  display: grid;
+  grid-template-columns: 260px 1fr;
+  gap: 1.5rem;
+  align-items: start;
 }
 
-[data-theme='dark'] {
-  --fty-head-bg: #646464;
+.sidebar {
+  position: sticky;
+  top: 5rem;
+  padding: 1.1rem;
+  background: var(--ifm-background-surface-color);
+  border: 1px solid var(--ifm-toc-border-color);
+  border-radius: 14px;
 }
 
-.panelHeading {
-  background-color: var(--fty-head-bg);
-  border-radius: 6px 6px 0 0;
-  font-size: 1.25em;
+.sidebarHeading {
+  margin: 0 0 0.75rem;
+  font-size: 1.05rem;
   font-weight: 700;
-  line-height: 1.25;
-  padding: 0.75em 1em;
+}
+
+.sidebarDivider {
+  margin: 0.6rem 0;
+  border: none;
+  border-top: 1px solid var(--ifm-toc-border-color);
+}
+
+.projectList {
+  display: flex;
+  flex-direction: column;
+  gap: 0.1rem;
+  max-height: 60vh;
+  overflow-y: auto;
 }
 
 .projectItem {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  padding: 0.45rem 0.5rem;
   cursor: pointer;
+  border-radius: 8px;
+  transition: background 0.15s ease;
 }
 
 .projectItem:hover {
-  background-color: var(--fty-head-bg);
+  background: var(--ifm-color-emphasis-100);
+}
+
+.projectItem input {
+  flex-shrink: 0;
+  accent-color: var(--ifm-color-primary);
+}
+
+.projectItemName {
+  overflow: hidden;
+  font-size: 0.9rem;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  flex: 1;
+}
+
+.projectItemCount {
+  flex-shrink: 0;
+  padding: 0.05rem 0.45rem;
+  font-size: 0.72rem;
+  font-weight: 600;
+  color: var(--ifm-color-emphasis-700);
+  background: var(--ifm-color-emphasis-100);
+  border-radius: 999px;
+}
+
+.issuesCount {
+  margin: 0 0 0.85rem;
+  font-size: 0.85rem;
+  color: var(--ifm-color-emphasis-700);
+}
+
+.issuesCount strong {
+  color: var(--ifm-font-color-base);
+}
+
+.issuesList {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.issueCard {
+  padding: 1rem 1.1rem;
+  background: var(--ifm-background-surface-color);
+  border: 1px solid var(--ifm-toc-border-color);
+  border-radius: 12px;
+  transition:
+    transform 0.15s ease,
+    box-shadow 0.15s ease,
+    border-color 0.15s ease;
+}
+
+.issueCard:hover {
+  border-color: var(--ifm-color-primary);
+  box-shadow: 0 6px 18px rgb(0 0 0 / 8%);
+  transform: translateY(-1px);
+}
+
+.issueTitle {
+  display: block;
+  margin-bottom: 0.3rem;
+  font-weight: 600;
+  line-height: 1.4;
+}
+
+.issueProject {
+  margin: 0 0 0.65rem;
+  font-size: 0.85rem;
+  color: var(--ifm-color-emphasis-700);
+}
+
+.issueLabels {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+}
+
+.label {
+  padding: 0.18rem 0.6rem;
+  font-size: 0.72rem;
+  font-weight: 600;
+  color: var(--ifm-color-emphasis-700);
+  background: var(--ifm-color-emphasis-100);
+  border: 1px solid var(--ifm-color-emphasis-300);
+  border-radius: 999px;
+}
+
+.label--bug {
+  color: #e0245e;
+  background: rgb(224 36 94 / 12%);
+  border-color: rgb(224 36 94 / 35%);
+}
+
+.label--helpWanted {
+  color: var(--ifm-color-primary);
+  background: color-mix(in srgb, var(--ifm-color-primary) 12%, transparent);
+  border-color: color-mix(in srgb, var(--ifm-color-primary) 40%, transparent);
+}
+
+.label--question {
+  color: #8957e5;
+  background: rgb(137 87 229 / 12%);
+  border-color: rgb(137 87 229 / 35%);
+}
+
+.label--goodFirstIssue {
+  color: #d4a72c;
+  background: rgb(212 167 44 / 14%);
+  border-color: rgb(212 167 44 / 40%);
+}
+
+.statusPanel {
+  padding: 1.1rem 1.25rem;
+  font-size: 0.95rem;
+  background: var(--ifm-background-surface-color);
+  border: 1px solid var(--ifm-toc-border-color);
+  border-radius: 12px;
+}
+
+.statusPanelError {
+  color: #e0245e;
+  border-color: rgb(224 36 94 / 35%);
+}
+
+.emptyState {
+  padding: 2.5rem 1rem;
+  text-align: center;
+  background: var(--ifm-background-surface-color);
+  border: 1px dashed var(--ifm-toc-border-color);
+  border-radius: 12px;
+}
+
+.emptyStateTitle {
+  margin: 0 0 0.25rem;
+  font-weight: 700;
+}
+
+.emptyStateSubtitle {
+  margin: 0;
+  font-size: 0.9rem;
+  color: var(--ifm-color-emphasis-700);
+}
+
+@media screen and (width < 768px) {
+  .layout {
+    grid-template-columns: 1fr;
+  }
+
+  .sidebar {
+    position: static;
+  }
+
+  .projectList {
+    max-height: none;
+  }
 }

--- a/src/components/Organizations/index.jsx
+++ b/src/components/Organizations/index.jsx
@@ -11,7 +11,7 @@ export default function Organizations({ maxItems, displayType }) {
   return (
     <ul className={styles.organizationsList}>
       {shuffle(orgs, { maxItems }).map((organization, index) => (
-        <li key={index}>
+        <li key={index} className={styles.organizationsListItem}>
           <OrganizationItem organization={organization} />
         </li>
       ))}
@@ -33,22 +33,23 @@ function filterOrganizationsByType(type) {
 
 function OrganizationItem({ organization }) {
   return (
-    <Link href={organization.link} target="_blank" rel="noreferrer" className={getOrganizationStyle(organization)}>
-      <img src={useBaseUrl(`/img/organizations/${organization.image}`)} alt={`${organization.name} is using Fastify`} />
+    <Link
+      href={organization.link}
+      target="_blank"
+      rel="noreferrer"
+      className={styles.organizationCard}
+      title={organization.name}>
+      <img
+        src={useBaseUrl(`/img/organizations/${organization.image}`)}
+        alt={`${organization.name} is using Fastify`}
+        loading="lazy"
+      />
     </Link>
   )
 }
 
-function getOrganizationStyle(organization) {
-  if (organization.sponsor) {
-    return styles[`sponsoring_${organization.tier}`]
-  }
-
-  return styles.using
-}
-
 function shuffle(data, { maxItems }) {
-  const shuffled = data.sort(() => 0.5 - Math.random())
+  const shuffled = [...data].sort(() => 0.5 - Math.random())
   if (maxItems) {
     return shuffled.slice(0, maxItems)
   }

--- a/src/components/Organizations/styles.module.css
+++ b/src/components/Organizations/styles.module.css
@@ -1,45 +1,63 @@
 .organizationsList {
-  margin: 0;
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(150px, 1fr));
+  gap: 1rem;
   padding: 0;
-  display: flex;
-  flex-wrap: wrap;
-  justify-content: space-around;
+  margin: 0;
   list-style: none;
-  place-items: center center;
 }
 
-[data-theme='dark'] .organizationsList {
-  background-color: var(--ifm-color-secondary-dark);
-  border-radius: var(--ifm-code-border-radius);
+.organizationsListItem {
+  margin: 0;
 }
 
-.organizationsList li {
-  align-items: center;
+.organizationCard {
   display: flex;
+  align-items: center;
   justify-content: center;
-  margin: 0.6rem;
-}
-
-.organizationsList li a {
+  height: 96px;
+  padding: 1.1rem;
+  background: #e4e4e4;
+  border: 1px solid rgb(0 0 0 / 8%);
+  border-radius: 14px;
   text-decoration: none;
+  box-shadow: 0 1px 2px rgb(0 0 0 / 6%);
+  transition:
+    transform 0.15s ease,
+    box-shadow 0.15s ease,
+    border-color 0.15s ease;
 }
 
-.organizationsList li a img {
-  transition: all 0.5s;
+.organizationCard:hover {
+  text-decoration: none;
+  border-color: var(--ifm-color-primary);
+  box-shadow: 0 10px 24px rgb(0 0 0 / 14%);
+  transform: translateY(-3px);
 }
 
-.organizationsList .using img {
-  max-width: 140px;
+.organizationCard img {
+  max-width: 100%;
+  max-height: 48px;
+  object-fit: contain;
+  transition: transform 0.2s ease;
 }
 
-.organizationsList .sponsoring_tier_3 img {
-  max-width: 140px;
+.organizationCard:hover img {
+  transform: scale(1.05);
 }
 
-.organizationsList .sponsoring_tier_4 img {
-  max-width: 160px;
-}
+@media screen and (width < 768px) {
+  .organizationsList {
+    grid-template-columns: repeat(auto-fill, minmax(120px, 1fr));
+    gap: 0.75rem;
+  }
 
-.organizationsList li a:hover img {
-  transform: scale(1.1);
+  .organizationCard {
+    height: 78px;
+    padding: 0.85rem;
+  }
+
+  .organizationCard img {
+    max-height: 38px;
+  }
 }

--- a/src/css/ecosystem.css
+++ b/src/css/ecosystem.css
@@ -1,33 +1,251 @@
-.grid-container {
+.ecosystem-page h2 {
+  margin-top: 2rem;
+}
+
+.plugins-table {
+  margin: 1.25rem 0 2.5rem;
+}
+
+.plugins-toolbar {
   display: grid;
   grid-template-columns: 1fr 1fr;
+  gap: 1rem 1.25rem;
+  align-items: end;
+  padding: 1.1rem;
+  margin-bottom: 1.25rem;
+  background: var(--ifm-background-surface-color);
+  border: 1px solid var(--ifm-toc-border-color);
+  border-radius: 14px;
 }
 
-.grid-container input {
-  width: 80%;
-  font-size: 1.2em;
-}
-
-.grid-item-header {
+.plugins-field {
   display: flex;
   flex-direction: column;
-  padding-bottom: 5px;
+  gap: 0.4rem;
+}
+
+.plugins-field__label {
+  font-size: 0.8rem;
+  font-weight: 700;
+  letter-spacing: 0.01em;
+  color: var(--ifm-font-color-base);
+  opacity: 0.75;
+}
+
+.plugins-field__control {
+  position: relative;
+  display: flex;
+  align-items: center;
+}
+
+.plugins-field__icon {
+  position: absolute;
+  left: 0.75rem;
+  color: var(--ifm-color-emphasis-500);
+  pointer-events: none;
+}
+
+.plugins-field__control input {
+  width: 100%;
+  padding: 0.55rem 2.2rem 0.55rem 2.2rem;
+  font-size: 0.95rem;
+  color: var(--ifm-font-color-base);
+  background: var(--ifm-background-color);
+  border: 1px solid var(--ifm-toc-border-color);
+  border-radius: 10px;
+  transition:
+    border-color 0.15s ease,
+    box-shadow 0.15s ease;
+}
+
+.plugins-field__control input::placeholder {
+  color: var(--ifm-color-emphasis-500);
+}
+
+.plugins-field__control input:focus {
+  outline: none;
+  border-color: var(--ifm-color-primary);
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--ifm-color-primary) 20%, transparent);
+}
+
+.plugins-field__clear {
+  position: absolute;
+  right: 0.55rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 22px;
+  height: 22px;
+  padding: 0;
+  color: var(--ifm-color-emphasis-600);
+  cursor: pointer;
+  background: transparent;
+  border: none;
+  border-radius: 50%;
+  transition:
+    background 0.15s ease,
+    color 0.15s ease;
+}
+
+.plugins-field__clear:hover {
+  color: var(--ifm-font-color-base);
+  background: var(--ifm-color-emphasis-200);
+}
+
+.plugins-toolbar__meta {
+  display: flex;
+  grid-column: 1 / -1;
+  align-items: center;
+  justify-content: space-between;
+  padding-top: 0.35rem;
+  border-top: 1px dashed var(--ifm-toc-border-color);
+}
+
+.plugins-count {
+  font-size: 0.85rem;
+  color: var(--ifm-color-emphasis-700);
+}
+
+.plugins-count strong {
+  color: var(--ifm-font-color-base);
+}
+
+.plugins-reset {
+  padding: 0.3rem 0.7rem;
+  font-size: 0.8rem;
+  font-weight: 600;
+  color: var(--ifm-color-primary);
+  cursor: pointer;
+  background: transparent;
+  border: 1px solid var(--ifm-color-primary);
+  border-radius: 999px;
+  transition:
+    background 0.15s ease,
+    color 0.15s ease;
+}
+
+.plugins-reset:hover {
+  color: var(--ifm-button-color, #fff);
+  background: var(--ifm-color-primary);
+}
+
+.plugins-list {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 0.85rem;
+  padding: 0;
+  margin: 0;
+  list-style: none;
+}
+
+.plugins-card {
+  display: flex;
+  flex-direction: column;
+  gap: 0.65rem;
+  padding: 1rem 1.1rem;
+  background: var(--ifm-background-surface-color);
+  border: 1px solid var(--ifm-toc-border-color);
+  border-radius: 12px;
+  transition:
+    transform 0.15s ease,
+    box-shadow 0.15s ease,
+    border-color 0.15s ease;
+}
+
+.plugins-card:hover {
+  border-color: var(--ifm-color-primary);
+  box-shadow: 0 6px 18px rgb(0 0 0 / 8%);
+  transform: translateY(-1px);
+}
+
+.plugins-card__header {
+  display: flex;
+  flex-wrap: nowrap;
+  gap: 0.75rem;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.plugins-card__name {
+  overflow: hidden;
+  min-width: 0;
+  font-family: var(--ifm-font-family-monospace);
+  font-size: 0.95rem;
+  font-weight: 600;
+  line-height: 1.4;
+  color: var(--ifm-font-color-base);
+  white-space: nowrap;
+  text-overflow: ellipsis;
+}
+
+.plugins-card__name:hover {
+  color: var(--ifm-color-primary);
+  text-decoration: none;
+}
+
+.plugins-badge {
+  flex-shrink: 0;
+  padding: 0.2rem 0.6rem;
+  font-size: 0.68rem;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  white-space: nowrap;
+  border: 1px solid;
+  border-radius: 999px;
+}
+
+.plugins-badge--official {
+  color: var(--ifm-color-primary);
+  background: color-mix(in srgb, var(--ifm-color-primary) 12%, transparent);
+  border-color: color-mix(in srgb, var(--ifm-color-primary) 45%, transparent);
+}
+
+.plugins-badge--community {
+  color: var(--ifm-color-emphasis-700);
+  background: var(--ifm-color-emphasis-100);
+  border-color: var(--ifm-color-emphasis-300);
+}
+
+.plugins-card__description {
+  overflow: hidden;
+  font-size: 0.9rem;
+  line-height: 1.5;
+  color: var(--ifm-color-emphasis-800);
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 4;
+}
+
+.plugins-card__description p {
+  margin: 0;
+}
+
+.plugins-empty {
+  padding: 2.5rem 1rem;
+  text-align: center;
+  background: var(--ifm-background-surface-color);
+  border: 1px dashed var(--ifm-toc-border-color);
+  border-radius: 12px;
+}
+
+.plugins-empty__title {
+  margin: 0 0 0.25rem;
   font-weight: 700;
 }
 
-.grid-item {
-  padding: 5px;
-  border-radius: 5px;
+.plugins-empty__subtitle {
+  margin: 0;
+  font-size: 0.9rem;
+  color: var(--ifm-color-emphasis-700);
 }
 
-.grid-item-0 {
-  background-color: var(--ifm-table-background);
-}
+@media screen and (width < 768px) {
+  .plugins-toolbar {
+    grid-template-columns: 1fr;
+  }
 
-.grid-item-1 {
-  background-color: var(--ifm-table-stripe-background);
-}
-
-.ecosystem-page h2 {
-  margin-top: 2rem;
+  .plugins-card__name {
+    font-size: 0.85rem;
+  }
 }

--- a/src/pages/ecosystem.mdx
+++ b/src/pages/ecosystem.mdx
@@ -20,7 +20,7 @@ export function PluginCount(props) {
 
 ## Core Plugins
 
-<PluginsTable plugins={plugins.corePlugins} />
+<PluginsTable plugins={plugins.corePlugins} variant="official" />
 
 ## Community Plugins
 
@@ -28,7 +28,7 @@ export function PluginCount(props) {
 
 > ℹ️ Note: Fastify community plugins are part of the broader community efforts, and we are thankful for these contributions. However, they are not maintained by the Fastify team. Use them at your own discretion. If you find malicious code, please [open an issue](https://github.com/fastify/fastify/issues/new/choose) or submit a PR to remove the plugin from the list.
 
-<PluginsTable plugins={plugins.communityPlugins} />
+<PluginsTable plugins={plugins.communityPlugins} variant="community" />
 
 ## How to add a plugin to the list
 


### PR DESCRIPTION
Proposal:

Visual refresh of three ecosystem-facing pages, replacing dated grid/table layouts with a consistent, modern card-based design language across the site.

#### 1. Plugins list (`/ecosystem`)
- Replaced the raw two-column `<input>` + grid-row layout with a proper toolbar (icon inside each field, per-field clear "×" button) and a single-column list of cards
- Each plugin card now shows an **Official** / **Community** badge (passed via a new `variant` prop on `<PluginsTable>`) so it's clear at a glance whether a plugin is maintained by the Fastify team
- Added a live "`N` of `M` plugins" counter and a "Reset filters" action
- Added a name autocomplete (native `<datalist>`) built from the plugin list, since plugin names are a known, closed set — description search stays free-text (autocomplete there would suggest against a set of values that don't really exist)
- Single-column card layout to keep the name/badge header from wrapping on long plugin names (e.g. `@blastorg/fastify-aws-dynamodb-cache`)

#### 2. Organizations ( Adopters ) (`/organizations` + homepage "Sponsors" section)
- Replaced the single flat panel (logos loosely wrapped inside one gray box) with a responsive grid of equal-size, individually bordered cards with a hover lift effect
- Fixed a card whose logo (Photon, solid-white SVG) was invisible on a white background — settled on a neutral light-gray chip for all cards, which keeps every logo (including near-white ones) legible in both light and dark site themes
- Softened the card border: it previously used the dark-theme border token (`--ifm-toc-border-color`), which read as too harsh against the light-gray "Sponsors" panel on the homepage; now uses a fixed, subtle neutral border + soft shadow instead

#### 3. Contribute / good first issues (`/contribute`)
- Sidebar project filter restyled as a sticky card with hover states and pill issue-counters, instead of a flat gray heading + plain checkboxes
- Issue cards restyled with hover elevation, and labels (`bug`, `help wanted`, `question`, `good first issue`) are now color-coded pills instead of uniform gray badges
- Added a "`N` of `M` open issues" counter above the list
- Nicer loading / error / empty states, consistent with the other pages
- Fixed `toggleProject` calling `setProjects` with the same mutated
  object reference instead of a new one


Screenshot Page Organizations ( Adopters ) :
---

before:

<img width="2038" height="934" alt="before" src="https://github.com/user-attachments/assets/5062cf45-e9b3-42b9-a8cc-4d12a8484c72" />


after:

<img width="2037" height="1029" alt="after" src="https://github.com/user-attachments/assets/3759f593-c22d-4e29-b249-008aa614e310" />

light mode: 

<img width="2041" height="684" alt="light-mode" src="https://github.com/user-attachments/assets/c05f6c29-cd23-4f03-b3e2-53125f45585e" />

---

Screenshot Page Contribute / good first issues :
---

before:

<img width="2039" height="1127" alt="Screenshot 2026-07-29 alle 12 19 03" src="https://github.com/user-attachments/assets/f570a282-4202-4bea-94e9-c58feea938b9" />


after:

<img width="2041" height="1262" alt="Screenshot 2026-07-29 alle 12 01 12" src="https://github.com/user-attachments/assets/8c5e11c2-a0a7-443f-a294-01fa7ab960d0" />


light mode: 

<img width="2043" height="1313" alt="Screenshot 2026-07-29 alle 12 01 31" src="https://github.com/user-attachments/assets/6d12a8e5-084f-433a-9929-0244e6e7faef" />


---

Screenshot Page Plugins list (`/ecosystem`) :
---

before:

<img width="2041" height="1115" alt="Screenshot 2026-07-29 alle 12 24 15" src="https://github.com/user-attachments/assets/e8d32cf1-c347-424c-8bc2-bbd3f036d6f3" />


after:

<img width="2029" height="1178" alt="Screenshot 2026-07-29 alle 12 02 37" src="https://github.com/user-attachments/assets/c55f93ca-e3e5-432b-90c0-bf75a10d74ae" />


<img width="2039" height="957" alt="Screenshot 2026-07-29 alle 12 23 34" src="https://github.com/user-attachments/assets/f784ca46-78b8-4260-944c-00666028ea1e" />


light mode: 

<img width="2039" height="1228" alt="Screenshot 2026-07-29 alle 12 02 05" src="https://github.com/user-attachments/assets/4010d771-ce4a-46a8-92a0-1ad95ba9d083" />


<img width="2039" height="1088" alt="Screenshot 2026-07-29 alle 12 02 21" src="https://github.com/user-attachments/assets/ac3c9737-05dc-4318-af08-3c1655f64dbf" />


---
Screenshot section sponsor ( home page ): 


before:

<img width="1450" height="540" alt="Screenshot 2026-07-29 alle 12 30 30" src="https://github.com/user-attachments/assets/04c80bb6-dee4-40e2-81d0-1b3cff4c1174" />
after:

<img width="1480" height="425" alt="Screenshot 2026-07-29 alle 12 03 55" src="https://github.com/user-attachments/assets/56e8a5e6-e39b-4f7f-bc61-7268708dc7d2" />

<img width="1397" height="429" alt="Screenshot 2026-07-29 alle 12 32 23" src="https://github.com/user-attachments/assets/d5019559-8e6f-4bd2-b7f8-6b1328c4a9bb" />

light mode:

<img width="1403" height="446" alt="Screenshot 2026-07-29 alle 12 31 46" src="https://github.com/user-attachments/assets/a4c7c854-0ddc-416f-851d-b91ff5b5c16d" />

---

cc @fastify/website 
