### PR TITLE
fix: shiki markdown theme

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -22,10 +22,24 @@ export default defineConfig({
 	base: baseConfig.base,
 	outDir: "./build",
 	markdown: {
+		shikiConfig: {
+			themes: {
+				light: "github-light",
+				dark: "github-dark",
+			},
+			defaultColor: "dark",
+		},
 		processor: markdownProcessor(),
 	},
 	integrations: [
 		mdx({
+			shikiConfig: {
+				themes: {
+					light: "github-light",
+					dark: "github-dark",
+				},
+				defaultColor: "dark",
+			},
 			processor: markdownProcessor(),
 		}),
 		sitemap(),


### PR DESCRIPTION
## Description

Define `shikiConfig` for markdown file, so it passes to the `Code`.

## Related Issues

Fixes #490 

## Check List

<!--
ATTENTION
Please follow this check list to ensure you've followed all items before opening this PR.
A PR will be merged only when the CI pipeline is successful and the approval process is completed.
-->

- [x] I have read the [Contributing Guidelines](./CONTRIBUTING.md)
