### PR TITLE
fix: copyright width

### DIFF
--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -96,7 +96,7 @@ const columns = [
     <div
       class="mt-12 flex flex-col gap-6 border-t border-border pt-6 text-xs text-muted"
     >
-      <p class="max-w-4xl leading-relaxed">
+      <p class="leading-relaxed">
         Copyright <OpenJSF /> and Fastify contributors. All rights
         reserved. The <OpenJSF /> has registered trademarks and uses trademarks.
         For a list of trademarks of the <OpenJSF /> please see our{" "}


### PR DESCRIPTION
## Description

Fixes the copyright width so that it takes the full width
<img width="3195" height="215" alt="image" src="https://github.com/user-attachments/assets/0d6b60f9-c6de-40d7-9c4c-3bb0c9eeab62" />


## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->

## Check List

<!--
ATTENTION
Please follow this check list to ensure you've followed all items before opening this PR.
A PR will be merged only when the CI pipeline is successful and the approval process is completed.
-->

- [x] I have read the [Contributing Guidelines](./CONTRIBUTING.md)
